### PR TITLE
Phase 1: provider abstraction + scalable.yaml manifest foundation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,13 @@
+# OpenAI credentials and model configuration.
+# Required: set your API key.
+OPENAI_API_KEY=your_openai_api_key_here
+
+# Embedding model used to vectorize document chunks.
+OPENAI_EMBEDDING_MODEL=text-embedding-3-large
+
+# Chat model used by the PydanticAI chatbot.
+OPENAI_CHAT_MODEL=gpt-5.2
+
+# Optional OpenAI-compatible base URL.
+# Example: https://api.openai.com/v1
+OPENAI_BASE_URL=your_openai_base_url_here

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,9 +2,9 @@ name: tests
 
 on:
   push:
-    branches: [develop, master, main]
+    branches: [develop, master, main, 'version/**']
   pull_request:
-    branches: [develop, master, main]
+    branches: [develop, master, main, 'version/**']
   workflow_dispatch:
 
 concurrency:
@@ -18,12 +18,19 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]
-        python-version: ["3.11", "3.12", "3.13"]
+        include:
+          - os: ubuntu-latest
+            python-version: "3.11"
+          - os: ubuntu-latest
+            python-version: "3.12"
+          - os: ubuntu-latest
+            python-version: "3.13"
+          - os: macos-latest
+            python-version: "3.11"
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0  # versioneer needs tags
+          fetch-depth: 0
 
       - uses: actions/setup-python@v5
         with:
@@ -37,6 +44,32 @@ jobs:
 
       - name: Run unit tests
         run: pytest tests/unit -v
+
+  validate-example-manifests:
+    name: validate example manifests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      - name: Install package
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e .[test]
+
+      - name: Validate docs examples
+        run: |
+          scalable validate docs/examples/scalable.minimal.yaml --target local
+          scalable validate docs/examples/scalable.gcam_stitches.yaml --target local
+
+      - name: Plan docs examples (dry-run)
+        run: |
+          scalable plan docs/examples/scalable.minimal.yaml --target local --dry-run --output /tmp/plan-minimal.json
+          scalable plan docs/examples/scalable.gcam_stitches.yaml --target local --dry-run --output /tmp/plan-gcam-stitches.json
 
   lint:
     name: ruff + mypy

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 capabilities/
 plans/
 .rooignore
+.env
 
 # -----------------------------
 # Python bytecode / caches

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+No notable changes yet.
+
+## [2.0.0a1] - 2026-05-19
+
 ### Added
 
 - New workflow architecture figure in [`docs/images/scalable_architecture.png`](docs/images/scalable_architecture.png).
@@ -17,6 +21,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - deterministic ``manifest.lock`` fingerprint generation
   - provider abstraction with ``LocalProvider`` and ``SlurmProvider``
   - docs pages: [`docs/manifest.rst`](docs/manifest.rst) and [`docs/providers.rst`](docs/providers.rst)
+- Provider abstractions and neutral planning data structures:
+  - ``DeploymentProvider`` protocol
+  - ``DeploymentSpec``, ``ScalePlan``, ``ResourceRequest``, and ``ClusterHandle``
+- New CLI subcommands and namespace stubs:
+  - ``scalable validate``
+  - ``scalable plan --dry-run``
+  - reserved stubs: ``run``, ``diagnose``, ``explain``, ``init-component``, ``compose``, ``report``
+- Example manifests for docs and CI validation:
+  - [`docs/examples/scalable.minimal.yaml`](docs/examples/scalable.minimal.yaml)
+  - [`docs/examples/scalable.gcam_stitches.yaml`](docs/examples/scalable.gcam_stitches.yaml)
 
 ### Changed
 
@@ -28,11 +42,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated container conda Python baseline to 3.11 in [`scalable/Dockerfile`](scalable/Dockerfile).
 - Expanded top-level exports in [`scalable/__init__.py`](scalable/__init__.py) to include
   ``ScalableSession``, ``DeploymentProvider``, ``LocalProvider``, and ``SlurmProvider``.
+- Package version now targets v2 alpha in [`pyproject.toml`](pyproject.toml) with
+  ``version = "2.0.0a1"``.
+- Global settings in [`scalable/common.py`](scalable/common.py) now include
+  ``manifest_path`` and ``target`` with env overrides ``SCALABLE_MANIFEST`` and
+  ``SCALABLE_TARGET``.
+- CI now includes:
+  - version branch triggers (``version/**``)
+  - macOS matrix coverage for LocalProvider paths
+  - a dedicated docs-manifest validation and dry-run planning job
+
+### Deprecated
+
+- Legacy ``ModelConfig`` Dockerfile/config auto-discovery path now emits a
+  ``DeprecationWarning`` when used outside the manifest adapter context;
+  manifest-driven configuration via ``scalable.yaml`` is the preferred path.
 
 ### Documentation
 
 - Added [`DISCLAIMER.md`](DISCLAIMER.md).
 - Updated [`LICENSE.md`](LICENSE.md) to BSD-3-Clause wording.
+- Added and cross-linked:
+  - [`docs/manifest.rst`](docs/manifest.rst)
+  - [`docs/providers.rst`](docs/providers.rst)
+  - v2 manifest-first usage examples in [`README.md`](README.md)
+  - onboarding links in [`docs/getting_started.rst`](docs/getting_started.rst)
 
 ## [1.1.0]
 
@@ -193,4 +227,5 @@ Most changes are source-compatible. Two situations to be aware of:
    loopback.
 
 [1.1.0]: https://github.com/JGCRI/scalable/compare/1.0.0...1.1.0
-[Unreleased]: https://github.com/JGCRI/scalable/compare/1.1.0...HEAD
+[2.0.0a1]: https://github.com/JGCRI/scalable/compare/1.1.0...version/2.0.0-phase1-provider-manifest
+[Unreleased]: https://github.com/JGCRI/scalable/compare/version/2.0.0-phase1-provider-manifest...HEAD

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - New workflow architecture figure in [`docs/images/scalable_architecture.png`](docs/images/scalable_architecture.png).
+- Manifest-driven v2 entry points:
+  - ``ScalableSession.from_yaml(...)`` lifecycle API
+  - ``scalable validate`` CLI command
+  - ``scalable plan --dry-run`` CLI command
+  - deterministic ``manifest.lock`` fingerprint generation
+  - provider abstraction with ``LocalProvider`` and ``SlurmProvider``
+  - docs pages: [`docs/manifest.rst`](docs/manifest.rst) and [`docs/providers.rst`](docs/providers.rst)
 
 ### Changed
 
@@ -19,6 +26,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Raised minimum supported Python version to 3.11 in [`pyproject.toml`](pyproject.toml).
 - Updated CI test matrix in [`.github/workflows/tests.yml`](.github/workflows/tests.yml) to run Python 3.11–3.12 only.
 - Updated container conda Python baseline to 3.11 in [`scalable/Dockerfile`](scalable/Dockerfile).
+- Expanded top-level exports in [`scalable/__init__.py`](scalable/__init__.py) to include
+  ``ScalableSession``, ``DeploymentProvider``, ``LocalProvider``, and ``SlurmProvider``.
 
 ### Documentation
 

--- a/README.md
+++ b/README.md
@@ -80,6 +80,50 @@ Bootstrap performs multiple SSH operations. For best reliability and usability, 
 
 ## Usage
 
+### Manifest-first workflow (v2.0.0 Phase 1)
+
+Scalable now supports a declarative manifest path for provider-neutral planning
+and validation.
+
+Create ``scalable.yaml``:
+
+```yaml
+version: 1
+project:
+  name: demo
+targets:
+  local:
+    provider: local
+    max_workers: 2
+    threads_per_worker: 1
+    processes: false
+    containers: none
+components:
+  gcam:
+    cpus: 1
+    memory: 1G
+tasks:
+  run_gcam:
+    component: gcam
+```
+
+Validate and plan without launching workers:
+
+```bash
+scalable validate ./scalable.yaml
+scalable plan ./scalable.yaml --target local --dry-run --output plan.json
+```
+
+Use the session API:
+
+```python
+from scalable import ScalableSession
+
+session = ScalableSession.from_yaml("./scalable.yaml", target="local")
+plan = session.plan(dry_run=True)
+print(plan.manifest_lock)
+```
+
 At runtime, create a cluster, register container targets, scale workers, and submit functions.
 
 ### 1. Create a cluster

--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
-![Scalable logo](docs/images/scalable_logo_nobkg.png)
+<p align="center">
+    <img src="docs/images/scalable_logo_nobkg.png" alt="Scalable logo" width="320" />
+</p>
 
 # Scalable
 
 [![PyPI](https://img.shields.io/pypi/v/scalable.svg)](https://pypi.org/project/scalable/)
-[![Python](https://img.shields.io/pypi/pyversions/scalable.svg)](https://pypi.org/project/scalable/)
+[![Python](https://img.shields.io/badge/python-3.11%20%7C%203.12%20%7C%203.13-blue.svg)](https://pypi.org/project/scalable/)
 [![Docs](https://readthedocs.org/projects/scalable/badge/?version=latest)](https://jgcri.github.io/scalable/)
 
 Scalable is a Python framework for orchestrating containerized, distributed workflows on HPC systems. It integrates container lifecycle management, scheduler-aware resource provisioning, and a Dask-based execution model so multi-stage scientific workflows can run consistently at scale.

--- a/docs/examples/scalable.gcam_stitches.yaml
+++ b/docs/examples/scalable.gcam_stitches.yaml
@@ -1,0 +1,34 @@
+version: 1
+project:
+  name: gcam-stitches-demo
+
+targets:
+  local:
+    provider: local
+    max_workers: 2
+    threads_per_worker: 1
+    processes: false
+    containers: none
+
+  hpc:
+    provider: slurm
+    queue: short
+    account: GCIMS
+    walltime: 02:00:00
+    interface: ib0
+    comm_port: 50051
+
+components:
+  gcam:
+    cpus: 2
+    memory: 8G
+  stitches:
+    cpus: 1
+    memory: 4G
+
+tasks:
+  run_gcam:
+    component: gcam
+  run_stitches:
+    component: stitches
+

--- a/docs/examples/scalable.minimal.yaml
+++ b/docs/examples/scalable.minimal.yaml
@@ -1,0 +1,21 @@
+version: 1
+project:
+  name: minimal-demo
+
+targets:
+  local:
+    provider: local
+    max_workers: 2
+    threads_per_worker: 1
+    processes: false
+    containers: none
+
+components:
+  worker:
+    cpus: 1
+    memory: 1G
+
+tasks:
+  run_worker:
+    component: worker
+

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -95,6 +95,7 @@ Next Steps
 
 After setup:
 
+* For declarative workflows, start with :doc:`manifest` and :doc:`providers`.
 * Review the :ref:`api_section` for worker, caching, and function interfaces.
 * Run examples from :ref:`demos_section`.
 * Use :ref:`how_tos_section` for targeted implementation guidance.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -45,6 +45,8 @@ Contents
    :maxdepth: 1
 
    workers
+   manifest
+   providers
    caching
    functions
 

--- a/docs/manifest.rst
+++ b/docs/manifest.rst
@@ -1,0 +1,89 @@
+Manifest-Driven Workflows (Phase 1)
+===================================
+
+Scalable v2.0.0 introduces a declarative manifest entry point, ``scalable.yaml``.
+This becomes the source of truth for targets, components, and task bindings.
+
+Schema v1 (required keys)
+-------------------------
+
+Top-level keys:
+
+* ``version`` (must be ``1``)
+* ``project``
+* ``targets``
+* ``components``
+* ``tasks``
+
+Minimal example:
+
+.. code-block:: yaml
+
+    version: 1
+    project:
+      name: demo
+
+    targets:
+      local:
+        provider: local
+        max_workers: 2
+        threads_per_worker: 1
+        processes: false
+        containers: none
+
+    components:
+      gcam:
+        image: /containers/gcam.sif
+        cpus: 2
+        memory: 8G
+        mounts:
+          /host/data: /data
+
+    tasks:
+      run_gcam:
+        component: gcam
+
+Validation commands
+-------------------
+
+Validate a manifest:
+
+.. code-block:: bash
+
+    scalable validate ./scalable.yaml
+
+Generate a deterministic dry-run plan:
+
+.. code-block:: bash
+
+    scalable plan ./scalable.yaml --target local --dry-run --output plan.json
+
+Phase 1 writes:
+
+* ``plan.json`` (provider-neutral plan payload)
+* ``manifest.lock`` (SHA-256 fingerprint of canonicalized manifest content)
+
+Environment variables
+---------------------
+
+* ``SCALABLE_MANIFEST``: default manifest path used by CLI/session
+* ``SCALABLE_TARGET``: default target override for auto-selection paths
+
+Migration note from imperative API
+----------------------------------
+
+Legacy imperative APIs remain supported in Phase 1:
+
+* ``SlurmCluster(...)``
+* ``cluster.add_container(...)``
+* ``cluster.add_workers(...)``
+
+The new manifest/session path is additive and can be adopted incrementally.
+
+Example manifests
+-----------------
+
+Reference examples are included in:
+
+* ``docs/examples/scalable.minimal.yaml``
+* ``docs/examples/scalable.gcam_stitches.yaml``

--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -1,0 +1,47 @@
+Provider Abstraction (Phase 1)
+==============================
+
+Phase 1 adds a provider-neutral execution seam.
+
+Built-in providers
+------------------
+
+* ``local`` via ``LocalProvider``
+* ``slurm`` via ``SlurmProvider``
+
+Provider contract
+-----------------
+
+Each provider follows the ``DeploymentProvider`` protocol:
+
+* ``validate(spec)``
+* ``build_cluster(spec)``
+* ``scale(cluster, plan)``
+* ``close(cluster)``
+
+The provider layer consumes ``DeploymentSpec`` and applies a ``ScalePlan``.
+
+Local provider
+--------------
+
+``LocalProvider`` runs a Dask ``LocalCluster`` for laptop and CI execution.
+It supports tag-aware scheduling compatible with
+``ScalableClient.submit(..., tag=...)``.
+
+Slurm provider
+--------------
+
+``SlurmProvider`` is a thin translation layer over the legacy ``SlurmCluster``
+path and preserves existing behavior while exposing a v2 manifest/session API.
+
+Registry and discovery
+----------------------
+
+The provider registry supports:
+
+* explicit runtime registration
+* lazy built-in resolution
+* optional Python entry-point discovery under ``scalable.providers``
+
+This is the extension hook for future cloud and Kubernetes providers.
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "scalable"
-version = "1.1.0"
+version = "2.0.0a1"
 description = "Assist with running models on job queing systems like Slurm"
 authors = [
     { name = "Shashank Lamba" },
@@ -29,6 +29,7 @@ dependencies = [
     "xxhash >= 3.4.1",
     "numpy >= 1.26.4",
     "pandas >= 2.2.3",
+    "pyyaml >= 6.0",
 ]
 classifiers = [
     "Intended Audience :: Science/Research",
@@ -54,15 +55,22 @@ dev = [
     "mypy >= 1.8",
     "pytest-cov >= 4.0",
 ]
+# v2.0.0 phase placeholders. Empty until later phases populate them so that
+# `pip install scalable[ai|cloud|kubernetes]` resolves cleanly from day one
+# and downstream pinning of the extras name is stable.
+ai = []
+cloud = []
+kubernetes = []
 
 [project.urls]
 "Github" = "https://github.com/JGCRI/scalable/tree/master/scalable"
 
 [project.scripts]
+scalable = "scalable.cli.main:main"
 scalable_bootstrap = "scalable.utilities:run_bootstrap"
 
-[tool.setuptools]
-packages = ["scalable"]
+[tool.setuptools.packages.find]
+include = ["scalable", "scalable.*"]
 
 [tool.setuptools.package-data]
 scalable = ["scalable_bootstrap.sh", "Dockerfile"]

--- a/scalable/__init__.py
+++ b/scalable/__init__.py
@@ -2,7 +2,10 @@
 
 Public API re-exports (kept stable for downstream code):
 
-* :class:`SlurmCluster`, :class:`JobQueueCluster`, :class:`ScalableClient`
+* Legacy v1 runtime classes: :class:`SlurmCluster`, :class:`JobQueueCluster`,
+  :class:`ScalableClient`
+* v2 session + provider surface: :class:`ScalableSession`,
+  :class:`DeploymentProvider`, :class:`LocalProvider`, :class:`SlurmProvider`
 * :func:`cacheable` and the :class:`*Type` hash wrappers from
   :mod:`scalable.caching`
 * :data:`SEED` and the :data:`settings` singleton from :mod:`scalable.common`
@@ -20,6 +23,8 @@ from .caching import *  # noqa: F401,F403  (legacy star-export)
 from .client import ScalableClient
 from .common import SEED, settings
 from .core import JobQueueCluster
+from .providers import DeploymentProvider, LocalProvider, SlurmProvider
+from .session import ScalableSession
 from .slurm import SlurmCluster
 
 try:
@@ -29,10 +34,14 @@ except PackageNotFoundError:  # pragma: no cover - source checkout w/o install
 
 __all__ = [
     "JobQueueCluster",
+    "DeploymentProvider",
+    "LocalProvider",
     "SEED",
     "ScalableClient",
+    "ScalableSession",
     "Security",
     "SlurmCluster",
+    "SlurmProvider",
     "__version__",
     "get_worker",
     "settings",

--- a/scalable/cli/__init__.py
+++ b/scalable/cli/__init__.py
@@ -1,0 +1,16 @@
+"""``scalable`` console-script CLI (v2.0.0 Phase 1).
+
+Phase 1 implements two subcommands -- ``scalable validate`` and
+``scalable plan --dry-run`` -- both of which operate purely on a manifest
+plus provider abstractions and never instantiate a scheduler.
+
+The remaining subcommand namespace (``run``, ``diagnose``, ``explain``,
+``init-component``, ``compose``, ``report``) is registered as Phase 1 stubs
+that print a phase-pointer message on invocation. This locks the UX
+namespace early so third-party CLIs don't collide with future Scalable
+verbs and so Phases 2-5 only fill behaviour rather than surface.
+"""
+
+from __future__ import annotations
+
+__all__: list[str] = []

--- a/scalable/cli/cmd_plan.py
+++ b/scalable/cli/cmd_plan.py
@@ -1,0 +1,45 @@
+"""Implementation for ``scalable plan``."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+from scalable.manifest.errors import ManifestError
+from scalable.session.session import ScalableSession
+
+
+def run_plan(
+    manifest_path: str,
+    *,
+    target: str | None,
+    dry_run: bool,
+    output: str,
+) -> int:
+    """Build a deterministic plan and write ``plan.json`` + ``manifest.lock``."""
+    if not dry_run:
+        print(
+            "Phase 1 only supports dry-run planning. Re-run with --dry-run.",
+            file=sys.stderr,
+        )
+        return 2
+
+    try:
+        session = ScalableSession.from_yaml(manifest_path, target=target)
+        plan = session.plan(dry_run=True)
+    except (ManifestError, OSError, ValueError, KeyError) as exc:
+        print(f"planning failed: {exc}", file=sys.stderr)
+        return 1
+
+    payload = plan.to_dict()
+    output_path = Path(output)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    lock_path = output_path.parent / "manifest.lock"
+    lock_path.write_text(plan.manifest_lock + "\n", encoding="utf-8")
+
+    print(json.dumps(payload, indent=2, sort_keys=True), file=sys.stdout)
+    return 0
+

--- a/scalable/cli/cmd_validate.py
+++ b/scalable/cli/cmd_validate.py
@@ -1,0 +1,58 @@
+"""Implementation for ``scalable validate``."""
+
+from __future__ import annotations
+
+import json
+import sys
+from typing import Any
+
+from scalable.manifest.errors import ManifestError
+from scalable.session.session import ScalableSession
+
+
+def _report_to_dict(report: Any) -> dict[str, Any]:
+    return {
+        "ok": bool(report.ok),
+        "errors": [
+            {
+                "path": issue.path,
+                "message": issue.message,
+                "code": issue.code,
+            }
+            for issue in report.errors
+        ],
+        "warnings": [
+            {
+                "path": issue.path,
+                "message": issue.message,
+                "code": issue.code,
+            }
+            for issue in report.warnings
+        ],
+    }
+
+
+def run_validate(manifest_path: str, *, target: str | None = None) -> int:
+    """Validate a manifest and print a structured JSON report."""
+    try:
+        session = ScalableSession.from_yaml(manifest_path, target=target)
+        report = session.validate()
+    except (ManifestError, OSError, ValueError, KeyError) as exc:
+        payload = {
+            "ok": False,
+            "errors": [
+                {
+                    "path": "manifest",
+                    "message": str(exc),
+                    "code": "E_MANIFEST",
+                }
+            ],
+            "warnings": [],
+        }
+        print(json.dumps(payload, indent=2, sort_keys=True), file=sys.stdout)
+        return 1
+
+    payload = _report_to_dict(report)
+    print(json.dumps(payload, indent=2, sort_keys=True), file=sys.stdout)
+    return 0 if report.ok else 1
+

--- a/scalable/cli/main.py
+++ b/scalable/cli/main.py
@@ -1,0 +1,50 @@
+"""``scalable`` console entry-point dispatcher.
+
+Phase 1 stub. The real subcommand wiring lands in WU-10
+(``scalable validate`` and ``scalable plan --dry-run``); the remaining
+subcommands (``run``, ``diagnose``, ``explain``, ``init-component``,
+``compose``, ``report``) print a phase-pointer message until later phases
+implement them.
+
+This module exists in WU-1 only so the ``scalable = "scalable.cli.main:main"``
+console script registered in ``pyproject.toml`` resolves at install time.
+"""
+
+from __future__ import annotations
+
+import sys
+
+_PHASE1_NOT_IMPLEMENTED_MESSAGE = (
+    "scalable CLI: Phase 1 scaffolding only. "
+    "Subcommands `validate` and `plan --dry-run` arrive in work-unit 10. "
+    "See plans/v2.0.0_phase1_plan.md."
+)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Entry-point referenced by ``[project.scripts] scalable = ...``.
+
+    Phase 1 placeholder: prints a clear "not yet wired up" message and
+    exits with status code 2 (matches argparse's convention for usage
+    errors) so downstream automation that introspects the exit code knows
+    to wait for WU-10.
+
+    Parameters
+    ----------
+    argv : list of str, optional
+        Argument vector excluding the program name. Defaults to
+        ``sys.argv[1:]``. Accepted for testability and to match the final
+        signature that WU-10 will deliver.
+
+    Returns
+    -------
+    int
+        Process exit code. Always ``2`` until WU-10 lands.
+    """
+    del argv  # unused in the WU-1 stub
+    print(_PHASE1_NOT_IMPLEMENTED_MESSAGE, file=sys.stderr)
+    return 2
+
+
+if __name__ == "__main__":  # pragma: no cover - exercised via console script
+    raise SystemExit(main(sys.argv[1:]))

--- a/scalable/cli/main.py
+++ b/scalable/cli/main.py
@@ -1,49 +1,128 @@
 """``scalable`` console entry-point dispatcher.
 
-Phase 1 stub. The real subcommand wiring lands in WU-10
-(``scalable validate`` and ``scalable plan --dry-run``); the remaining
-subcommands (``run``, ``diagnose``, ``explain``, ``init-component``,
-``compose``, ``report``) print a phase-pointer message until later phases
-implement them.
+Phase 1 ships two implemented subcommands:
 
-This module exists in WU-1 only so the ``scalable = "scalable.cli.main:main"``
-console script registered in ``pyproject.toml`` resolves at install time.
+* ``scalable validate``
+* ``scalable plan --dry-run``
+
+The namespace for later-phase verbs (``run``, ``diagnose``, ``explain``,
+``init-component``, ``compose``, ``report``) is reserved as explicit stubs.
 """
 
 from __future__ import annotations
 
+import argparse
 import sys
 
-_PHASE1_NOT_IMPLEMENTED_MESSAGE = (
-    "scalable CLI: Phase 1 scaffolding only. "
-    "Subcommands `validate` and `plan --dry-run` arrive in work-unit 10. "
-    "See plans/v2.0.0_phase1_plan.md."
-)
+from scalable.common import settings
+
+from .cmd_plan import run_plan
+from .cmd_validate import run_validate
+
+_STUB_COMMANDS: dict[str, str] = {
+    "run": "Phase 2+",
+    "diagnose": "Phase 4",
+    "explain": "Phase 4",
+    "init-component": "Phase 4",
+    "compose": "Phase 4",
+    "report": "Phase 2",
+}
+
+
+def _handle_validate(args: argparse.Namespace) -> int:
+    return run_validate(args.manifest, target=args.target)
+
+
+def _handle_plan(args: argparse.Namespace) -> int:
+    return run_plan(
+        args.manifest,
+        target=args.target,
+        dry_run=bool(args.dry_run),
+        output=args.output,
+    )
+
+
+def _make_stub_handler(command: str, phase: str):
+    def _handler(_: argparse.Namespace) -> int:
+        print(
+            f"scalable {command}: not yet available; planned for {phase}.",
+            file=sys.stderr,
+        )
+        return 2
+
+    return _handler
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="scalable")
+    subparsers = parser.add_subparsers(dest="command")
+
+    validate_parser = subparsers.add_parser(
+        "validate",
+        help="Validate a scalable.yaml manifest and print a structured report",
+    )
+    validate_parser.add_argument(
+        "manifest",
+        nargs="?",
+        default=settings.manifest_path,
+        help="Path to scalable.yaml (default: SCALABLE_MANIFEST or ./scalable.yaml)",
+    )
+    validate_parser.add_argument(
+        "--target",
+        default=None,
+        help="Optional target name override (default: manifest auto resolution)",
+    )
+    validate_parser.set_defaults(handler=_handle_validate)
+
+    plan_parser = subparsers.add_parser(
+        "plan",
+        help="Build a provider-neutral execution plan from a manifest",
+    )
+    plan_parser.add_argument(
+        "manifest",
+        nargs="?",
+        default=settings.manifest_path,
+        help="Path to scalable.yaml (default: SCALABLE_MANIFEST or ./scalable.yaml)",
+    )
+    plan_parser.add_argument(
+        "--target",
+        default=None,
+        help="Optional target name override (default: manifest auto resolution)",
+    )
+    plan_parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Required in Phase 1. Non-dry planning is not implemented yet.",
+    )
+    plan_parser.add_argument(
+        "--output",
+        default="plan.json",
+        help="Plan output path (default: ./plan.json)",
+    )
+    plan_parser.set_defaults(handler=_handle_plan)
+
+    for command, phase in _STUB_COMMANDS.items():
+        stub_parser = subparsers.add_parser(command, help=f"Reserved command (planned for {phase})")
+        stub_parser.set_defaults(handler=_make_stub_handler(command, phase))
+
+    return parser
 
 
 def main(argv: list[str] | None = None) -> int:
-    """Entry-point referenced by ``[project.scripts] scalable = ...``.
+    """Run the ``scalable`` CLI and return a process-compatible exit code."""
+    parser = _build_parser()
+    args_list = sys.argv[1:] if argv is None else argv
+    try:
+        args = parser.parse_args(args_list)
+    except SystemExit as exc:
+        return int(exc.code)
 
-    Phase 1 placeholder: prints a clear "not yet wired up" message and
-    exits with status code 2 (matches argparse's convention for usage
-    errors) so downstream automation that introspects the exit code knows
-    to wait for WU-10.
+    handler = getattr(args, "handler", None)
+    if handler is None:
+        parser.print_help(sys.stderr)
+        return 2
 
-    Parameters
-    ----------
-    argv : list of str, optional
-        Argument vector excluding the program name. Defaults to
-        ``sys.argv[1:]``. Accepted for testability and to match the final
-        signature that WU-10 will deliver.
-
-    Returns
-    -------
-    int
-        Process exit code. Always ``2`` until WU-10 lands.
-    """
-    del argv  # unused in the WU-1 stub
-    print(_PHASE1_NOT_IMPLEMENTED_MESSAGE, file=sys.stderr)
-    return 2
+    return int(handler(args))
 
 
 if __name__ == "__main__":  # pragma: no cover - exercised via console script

--- a/scalable/common.py
+++ b/scalable/common.py
@@ -30,6 +30,7 @@ __all__ = ["logger", "settings", "Settings", "SEED", "cachedir", "DEFAULT_SEED"]
 
 DEFAULT_SEED: int = 987654321
 DEFAULT_CACHE_DIR: str = "./cache"
+DEFAULT_MANIFEST_PATH: str = "./scalable.yaml"
 
 
 @dataclass
@@ -51,6 +52,10 @@ class Settings:
     seed: int = field(
         default_factory=lambda: int(os.environ.get("SCALABLE_SEED", DEFAULT_SEED))
     )
+    manifest_path: str = field(
+        default_factory=lambda: os.environ.get("SCALABLE_MANIFEST", DEFAULT_MANIFEST_PATH)
+    )
+    target: str | None = field(default_factory=lambda: os.environ.get("SCALABLE_TARGET"))
 
 
 #: Process-wide settings singleton. Mutating attributes on this instance

--- a/scalable/manifest/__init__.py
+++ b/scalable/manifest/__init__.py
@@ -1,0 +1,23 @@
+"""Declarative ``scalable.yaml`` manifest layer (v2.0.0 Phase 1).
+
+This package is the durable, provider-neutral source of truth for a Scalable
+project. It supersedes the legacy ``Dockerfile``-as-config discovery driven
+by :class:`scalable.utilities.ModelConfig`, which is preserved with a
+deprecation warning during the v2.0.0 transition.
+
+Public Phase 1 surface (populated by subsequent work units):
+
+* :mod:`scalable.manifest.schema` -- frozen schema dataclasses + ``SCHEMA_VERSION``.
+* :mod:`scalable.manifest.parser` -- YAML loader with ``${VAR}`` expansion.
+* :mod:`scalable.manifest.validate` -- cross-field validation + report types.
+* :mod:`scalable.manifest.adapter` -- pure ``ManifestModel`` -> legacy
+  :class:`scalable.core.JobQueueCluster` translation reused by every provider.
+* :mod:`scalable.manifest.errors` -- exception hierarchy.
+
+The schema is versioned (``version: 1``) so Phase 3 cloud overlays and Phase 4
+AI migration assistants can evolve without breaking existing manifests.
+"""
+
+from __future__ import annotations
+
+__all__: list[str] = []

--- a/scalable/manifest/adapter.py
+++ b/scalable/manifest/adapter.py
@@ -1,0 +1,92 @@
+"""Manifest -> legacy cluster adapter functions (Phase 1 WU-7)."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import TYPE_CHECKING, Any
+
+from scalable.utilities import model_config_adapter_context
+
+if TYPE_CHECKING:
+    from scalable.providers.base import DeploymentSpec
+
+__all__ = [
+    "add_components_to_legacy_cluster",
+    "build_slurm_cluster_kwargs",
+    "create_legacy_slurm_cluster",
+]
+
+
+def build_slurm_cluster_kwargs(spec: DeploymentSpec) -> dict[str, Any]:
+    """Translate ``targets.<name>`` options into ``SlurmCluster`` kwargs."""
+    options = spec.target.options
+    kwargs: dict[str, Any] = {
+        "queue": options.get("queue"),
+        "account": options.get("account"),
+        "walltime": options.get("walltime"),
+        "interface": options.get("interface"),
+        "name": options.get("name"),
+        "logs_location": options.get("logs_location"),
+        "suppress_logs": options.get("suppress_logs", False),
+    }
+    if "comm_port" in options:
+        kwargs["comm_port"] = options["comm_port"]
+    return kwargs
+
+
+def create_legacy_slurm_cluster(spec: DeploymentSpec, *, cluster_cls: Any) -> Any:
+    """Instantiate a legacy Slurm cluster under adapter compatibility context.
+
+    This suppresses the direct ``ModelConfig`` deprecation warning emitted by
+    :class:`scalable.utilities.ModelConfig`, since this call path is the
+    intentional bridge from manifests to legacy APIs.
+    """
+    kwargs = build_slurm_cluster_kwargs(spec)
+    with model_config_adapter_context():
+        return cluster_cls(**kwargs)
+
+
+def add_components_to_legacy_cluster(
+    spec: DeploymentSpec,
+    cluster: Any,
+    *,
+    components: Iterable[str] | None = None,
+) -> list[str]:
+    """Apply manifest components to a legacy cluster via ``add_container``.
+
+    Parameters
+    ----------
+    spec
+        Deployment spec containing parsed components.
+    cluster
+        Object exposing ``add_container(...)`` (e.g. ``SlurmCluster``).
+    components
+        Optional subset of component names to add. Defaults to all components.
+
+    Returns
+    -------
+    list[str]
+        Component names that were added.
+    """
+    if not hasattr(cluster, "add_container"):
+        raise TypeError("cluster does not expose add_container(...)")
+
+    if components is None:
+        selected = list(spec.components)
+    else:
+        selected = list(components)
+
+    added: list[str] = []
+    for component_name in selected:
+        component = spec.components[component_name]
+        cluster.add_container(
+            tag=component_name,
+            dirs=dict(component.mounts),
+            path=component.image,
+            cpus=component.cpus,
+            memory=component.memory,
+            preload_script=component.preload_script,
+        )
+        added.append(component_name)
+
+    return added

--- a/scalable/manifest/errors.py
+++ b/scalable/manifest/errors.py
@@ -1,0 +1,37 @@
+"""Exception hierarchy for the manifest layer.
+
+Each error type carries enough context (path, key, value) to drive the
+``scalable validate`` CLI's structured report and the Phase 4 AI migration
+assistant's diff output. They subclass :class:`ValueError` so legacy
+callers' ``except ValueError`` clauses keep working.
+"""
+
+from __future__ import annotations
+
+
+class ManifestError(ValueError):
+    """Base class for all manifest-layer errors."""
+
+
+class ManifestParseError(ManifestError):
+    """Raised when YAML parsing or env-var expansion fails."""
+
+
+class ManifestSchemaError(ManifestError):
+    """Raised when the document violates the v1 schema (missing required
+    fields, wrong types, unknown top-level keys, version mismatch).
+    """
+
+
+class ManifestValidationError(ManifestError):
+    """Raised when cross-field validation fails (unknown component
+    reference, unresolvable provider, malformed memory string, ...).
+    """
+
+
+__all__ = [
+    "ManifestError",
+    "ManifestParseError",
+    "ManifestSchemaError",
+    "ManifestValidationError",
+]

--- a/scalable/manifest/parser.py
+++ b/scalable/manifest/parser.py
@@ -1,0 +1,426 @@
+"""YAML loader for ``scalable.yaml`` v1 manifests.
+
+Phase 1 responsibilities:
+
+* Load YAML from a file path, string, or already-parsed mapping.
+* Expand ``${VAR}`` and ``${VAR:-default}`` references against
+  :data:`os.environ` so manifests stay portable across machines without
+  templating tools.
+* Reject unknown top-level keys (defense-in-depth against typos like
+  ``component:``); unknown keys *inside* ``targets[*]`` are passed through
+  to the provider — see Phase 1 plan §3.3 (forward compatibility for
+  Phase 3 cloud / Kubernetes overlays).
+* Refuse documents whose ``version:`` differs from
+  :data:`scalable.manifest.schema.SCHEMA_VERSION` with a clear message.
+* Build immutable :class:`~scalable.manifest.schema.ManifestModel` and
+  child dataclasses; cross-field semantic checks are deferred to
+  :mod:`scalable.manifest.validate`.
+
+The parser is deterministic — given the same input bytes and environment
+the resulting :class:`ManifestModel.raw` is byte-identical, which is a
+prerequisite for the Phase 1 ``manifest_lock`` fingerprint computed by
+:mod:`scalable.planning.dryrun`.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from .errors import ManifestParseError, ManifestSchemaError
+from .schema import (
+    SCHEMA_VERSION,
+    ComponentConfig,
+    ManifestModel,
+    ProjectConfig,
+    TargetConfig,
+    TaskConfig,
+)
+
+__all__ = [
+    "expand_env_vars",
+    "load_manifest",
+    "parse_manifest",
+]
+
+# Recognised top-level keys for v1. The order is preserved for diagnostic
+# messages; semantically the set is what matters.
+_TOP_LEVEL_KEYS: frozenset[str] = frozenset(
+    {"version", "project", "targets", "components", "tasks"}
+)
+_REQUIRED_TOP_LEVEL_KEYS: frozenset[str] = frozenset({"version", "project"})
+
+# Recognised per-component keys. Unknown keys here are a hard error —
+# component definitions are part of the schema, not provider passthrough.
+_COMPONENT_KEYS: frozenset[str] = frozenset(
+    {"image", "runtime", "cpus", "memory", "mounts", "env", "tags", "preload_script"}
+)
+_TASK_KEYS: frozenset[str] = frozenset({"component", "cache", "outputs"})
+_PROJECT_KEYS: frozenset[str] = frozenset({"name", "default_storage", "local_cache"})
+
+# ${VAR} and ${VAR:-default} expansion. Anchored to require curly braces so
+# bare ``$HOME`` style sequences (which YAML users frequently want as
+# literals in mounts/paths) are left untouched.
+_ENV_VAR_PATTERN: re.Pattern[str] = re.compile(
+    r"""
+    \$\{                       # opening ${
+        (?P<name>[A-Za-z_][A-Za-z0-9_]*)
+        (?:                    # optional :- default form
+            :-(?P<default>[^}]*)
+        )?
+    \}                         # closing }
+    """,
+    re.VERBOSE,
+)
+
+
+def expand_env_vars(value: Any, env: Mapping[str, str] | None = None) -> Any:
+    """Recursively expand ``${VAR}`` references inside a parsed YAML tree.
+
+    Parameters
+    ----------
+    value : Any
+        A parsed YAML value (``str``, ``int``, ``bool``, ``None``,
+        ``list``, ``dict``).
+    env : Mapping[str, str] | None
+        Environment to resolve against. Defaults to :data:`os.environ`.
+        An explicit, restricted mapping is supported so unit tests stay
+        deterministic.
+
+    Returns
+    -------
+    Any
+        A value of the same shape, with ``${VAR}`` references replaced.
+
+    Raises
+    ------
+    ManifestParseError
+        If a ``${VAR}`` reference has no value and no ``${VAR:-default}``
+        clause was provided.
+    """
+    environment = os.environ if env is None else env
+
+    def _expand_str(s: str) -> str:
+        def _sub(match: re.Match[str]) -> str:
+            name = match.group("name")
+            default = match.group("default")
+            if name in environment:
+                return environment[name]
+            if default is not None:
+                return default
+            raise ManifestParseError(
+                f"environment variable {name!r} referenced in manifest "
+                f"is not set and no default (${{{name}:-...}}) was provided"
+            )
+
+        return _ENV_VAR_PATTERN.sub(_sub, s)
+
+    if isinstance(value, str):
+        return _expand_str(value)
+    if isinstance(value, list):
+        return [expand_env_vars(item, env) for item in value]
+    if isinstance(value, dict):
+        return {k: expand_env_vars(v, env) for k, v in value.items()}
+    return value
+
+
+def load_manifest(
+    source: str | os.PathLike[str],
+    *,
+    env: Mapping[str, str] | None = None,
+) -> ManifestModel:
+    """Load and parse a manifest from a filesystem path.
+
+    Parameters
+    ----------
+    source : str or path-like
+        Path to a ``scalable.yaml`` document.
+    env : Mapping[str, str] | None
+        Optional environment override for ``${VAR}`` expansion. Defaults
+        to :data:`os.environ`.
+
+    Returns
+    -------
+    ManifestModel
+        A frozen, immutable model.
+
+    Raises
+    ------
+    ManifestParseError
+        If the file cannot be read or the YAML is malformed.
+    ManifestSchemaError
+        If the document violates the v1 schema.
+    """
+    path = Path(source)
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError as exc:  # pragma: no cover - exercised via integration
+        raise ManifestParseError(
+            f"could not read manifest at {path!s}: {exc}"
+        ) from exc
+    return parse_manifest(text, env=env, source_path=str(path))
+
+
+def parse_manifest(
+    source: str | Mapping[str, Any],
+    *,
+    env: Mapping[str, str] | None = None,
+    source_path: str | None = None,
+) -> ManifestModel:
+    """Parse a manifest from a YAML string or already-parsed mapping.
+
+    Parameters
+    ----------
+    source : str or Mapping
+        Either a YAML document as a string or an already-loaded mapping.
+        Tests usually pass a mapping directly so they don't depend on
+        round-tripping YAML.
+    env : Mapping[str, str] | None
+        Environment override for ``${VAR}`` expansion.
+    source_path : str | None
+        Optional originating file path (carried into ``ManifestModel``).
+
+    Returns
+    -------
+    ManifestModel
+    """
+    if isinstance(source, str):
+        try:
+            raw_doc = yaml.safe_load(source)
+        except yaml.YAMLError as exc:
+            raise ManifestParseError(f"malformed YAML: {exc}") from exc
+    else:
+        raw_doc = dict(source)
+
+    if raw_doc is None:
+        raise ManifestSchemaError("manifest document is empty")
+    if not isinstance(raw_doc, dict):
+        raise ManifestSchemaError(
+            f"manifest must be a mapping at the top level, got {type(raw_doc).__name__}"
+        )
+
+    expanded = expand_env_vars(raw_doc, env=env)
+    if not isinstance(expanded, dict):  # pragma: no cover - defensive
+        raise ManifestSchemaError("manifest top-level must remain a mapping after expansion")
+
+    _check_top_level_keys(expanded)
+    _check_version(expanded)
+
+    project = _build_project(expanded.get("project") or {})
+    targets = _build_targets(expanded.get("targets") or {})
+    components = _build_components(expanded.get("components") or {})
+    tasks = _build_tasks(expanded.get("tasks") or {})
+
+    return ManifestModel(
+        version=int(expanded["version"]),
+        project=project,
+        targets=targets,
+        components=components,
+        tasks=tasks,
+        raw=expanded,
+        source_path=source_path,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Internal builders
+# ---------------------------------------------------------------------------
+
+
+def _check_top_level_keys(doc: Mapping[str, Any]) -> None:
+    unknown = set(doc) - _TOP_LEVEL_KEYS
+    if unknown:
+        raise ManifestSchemaError(
+            "unknown top-level manifest key(s): "
+            + ", ".join(sorted(unknown))
+            + f" (allowed: {sorted(_TOP_LEVEL_KEYS)})"
+        )
+    missing = _REQUIRED_TOP_LEVEL_KEYS - set(doc)
+    if missing:
+        raise ManifestSchemaError(
+            "manifest missing required top-level key(s): " + ", ".join(sorted(missing))
+        )
+
+
+def _check_version(doc: Mapping[str, Any]) -> None:
+    version = doc.get("version")
+    if not isinstance(version, int) or isinstance(version, bool):
+        raise ManifestSchemaError(
+            f"manifest 'version' must be an integer, got {type(version).__name__}"
+        )
+    if version != SCHEMA_VERSION:
+        raise ManifestSchemaError(
+            f"manifest schema version {version!r} is not supported by this "
+            f"Scalable build (expected {SCHEMA_VERSION}). Upgrade Scalable or "
+            "downgrade the manifest."
+        )
+
+
+def _require_mapping(value: Any, *, where: str) -> dict[str, Any]:
+    if value is None:
+        return {}
+    if not isinstance(value, Mapping):
+        raise ManifestSchemaError(
+            f"{where} must be a mapping, got {type(value).__name__}"
+        )
+    return dict(value)
+
+
+def _build_project(value: Any) -> ProjectConfig:
+    block = _require_mapping(value, where="'project'")
+    unknown = set(block) - _PROJECT_KEYS
+    if unknown:
+        raise ManifestSchemaError(
+            f"unknown 'project' key(s): {', '.join(sorted(unknown))} "
+            f"(allowed: {sorted(_PROJECT_KEYS)})"
+        )
+    name = block.get("name")
+    if not isinstance(name, str) or not name.strip():
+        raise ManifestSchemaError("'project.name' is required and must be a non-empty string")
+    default_storage = block.get("default_storage")
+    if default_storage is not None and not isinstance(default_storage, str):
+        raise ManifestSchemaError("'project.default_storage' must be a string when set")
+    local_cache = block.get("local_cache")
+    if local_cache is not None and not isinstance(local_cache, str):
+        raise ManifestSchemaError("'project.local_cache' must be a string when set")
+    return ProjectConfig(
+        name=name.strip(),
+        default_storage=default_storage,
+        local_cache=local_cache,
+    )
+
+
+def _build_targets(value: Any) -> dict[str, TargetConfig]:
+    block = _require_mapping(value, where="'targets'")
+    out: dict[str, TargetConfig] = {}
+    for tname, tspec in block.items():
+        if not isinstance(tname, str) or not tname:
+            raise ManifestSchemaError(f"target name must be a non-empty string, got {tname!r}")
+        spec_map = _require_mapping(tspec, where=f"'targets.{tname}'")
+        provider = spec_map.pop("provider", None)
+        if not isinstance(provider, str) or not provider:
+            raise ManifestSchemaError(
+                f"'targets.{tname}.provider' is required and must be a string"
+            )
+        # Everything else is provider-specific options. We deliberately do
+        # not validate keys here so Phase 3 cloud overlays can carry
+        # forward-compatible fields without a parser change. The validator
+        # surfaces unknown keys as warnings.
+        out[tname] = TargetConfig(name=tname, provider=provider, options=dict(spec_map))
+    return out
+
+
+def _build_components(value: Any) -> dict[str, ComponentConfig]:
+    block = _require_mapping(value, where="'components'")
+    out: dict[str, ComponentConfig] = {}
+    for cname, cspec in block.items():
+        if not isinstance(cname, str) or not cname:
+            raise ManifestSchemaError(
+                f"component name must be a non-empty string, got {cname!r}"
+            )
+        spec_map = _require_mapping(cspec, where=f"'components.{cname}'")
+        unknown = set(spec_map) - _COMPONENT_KEYS
+        if unknown:
+            raise ManifestSchemaError(
+                f"unknown 'components.{cname}' key(s): {', '.join(sorted(unknown))} "
+                f"(allowed: {sorted(_COMPONENT_KEYS)})"
+            )
+        cpus_value = spec_map.get("cpus", 1)
+        if not isinstance(cpus_value, int) or isinstance(cpus_value, bool) or cpus_value < 1:
+            raise ManifestSchemaError(
+                f"'components.{cname}.cpus' must be a positive integer (got {cpus_value!r})"
+            )
+        image_value = spec_map.get("image")
+        if image_value is not None and not isinstance(image_value, str):
+            raise ManifestSchemaError(
+                f"'components.{cname}.image' must be a string when set"
+            )
+        runtime_value = spec_map.get("runtime")
+        if runtime_value is not None and not isinstance(runtime_value, str):
+            raise ManifestSchemaError(
+                f"'components.{cname}.runtime' must be a string when set"
+            )
+        memory_value = spec_map.get("memory")
+        if memory_value is not None and not isinstance(memory_value, str):
+            raise ManifestSchemaError(
+                f"'components.{cname}.memory' must be a string when set "
+                f"(e.g. '8G', '500MB'); got {type(memory_value).__name__}"
+            )
+        mounts_value = spec_map.get("mounts") or {}
+        if not isinstance(mounts_value, Mapping):
+            raise ManifestSchemaError(
+                f"'components.{cname}.mounts' must be a mapping of host:container paths"
+            )
+        env_value = spec_map.get("env") or {}
+        if not isinstance(env_value, Mapping):
+            raise ManifestSchemaError(
+                f"'components.{cname}.env' must be a mapping of NAME:VALUE pairs"
+            )
+        # Coerce env values to str so later providers don't have to.
+        env_map = {str(k): str(v) for k, v in env_value.items()}
+        tags_value = spec_map.get("tags") or []
+        if not isinstance(tags_value, list) or not all(isinstance(t, str) for t in tags_value):
+            raise ManifestSchemaError(
+                f"'components.{cname}.tags' must be a list of strings"
+            )
+        preload_value = spec_map.get("preload_script")
+        if preload_value is not None and not isinstance(preload_value, str):
+            raise ManifestSchemaError(
+                f"'components.{cname}.preload_script' must be a string when set"
+            )
+        out[cname] = ComponentConfig(
+            name=cname,
+            image=image_value,
+            runtime=runtime_value,
+            cpus=cpus_value,
+            memory=memory_value,
+            mounts=dict(mounts_value),
+            env=env_map,
+            tags=list(tags_value),
+            preload_script=preload_value,
+        )
+    return out
+
+
+def _build_tasks(value: Any) -> dict[str, TaskConfig]:
+    block = _require_mapping(value, where="'tasks'")
+    out: dict[str, TaskConfig] = {}
+    for tname, tspec in block.items():
+        if not isinstance(tname, str) or not tname:
+            raise ManifestSchemaError(
+                f"task name must be a non-empty string, got {tname!r}"
+            )
+        spec_map = _require_mapping(tspec, where=f"'tasks.{tname}'")
+        unknown = set(spec_map) - _TASK_KEYS
+        if unknown:
+            raise ManifestSchemaError(
+                f"unknown 'tasks.{tname}' key(s): {', '.join(sorted(unknown))} "
+                f"(allowed: {sorted(_TASK_KEYS)})"
+            )
+        component = spec_map.get("component")
+        if not isinstance(component, str) or not component:
+            raise ManifestSchemaError(
+                f"'tasks.{tname}.component' is required and must be a string"
+            )
+        cache = spec_map.get("cache", False)
+        if not isinstance(cache, bool):
+            raise ManifestSchemaError(
+                f"'tasks.{tname}.cache' must be a boolean when set"
+            )
+        outputs = spec_map.get("outputs") or {}
+        if not isinstance(outputs, Mapping):
+            raise ManifestSchemaError(
+                f"'tasks.{tname}.outputs' must be a mapping when set"
+            )
+        out[tname] = TaskConfig(
+            name=tname,
+            component=component,
+            cache=cache,
+            outputs={str(k): str(v) for k, v in outputs.items()},
+        )
+    return out

--- a/scalable/manifest/schema.py
+++ b/scalable/manifest/schema.py
@@ -1,0 +1,204 @@
+"""Frozen ``scalable.yaml`` v1 schema dataclasses.
+
+The schema is intentionally implemented with stdlib :mod:`dataclasses` rather
+than :mod:`pydantic` so manifest validation works without the optional
+``scalable[ai]`` extra installed (see Phase 1 plan, open question #1).
+
+The shape mirrors the canonical example in
+``plans/v2.0.0_development_phases.md`` and is **frozen for v2.0.0**: any
+schema change requires bumping :data:`SCHEMA_VERSION`. Phase 3 overlays and
+Phase 4 AI migration assistants are expected to layer on top of this v1
+without breaking existing manifests.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+#: Current manifest schema version. The parser refuses higher versions with
+#: an actionable error so users on older Scalable releases see a clear
+#: incompatibility message rather than a silent partial parse.
+SCHEMA_VERSION: int = 1
+
+
+@dataclass(frozen=True)
+class ProjectConfig:
+    """Top-level project metadata block.
+
+    Attributes
+    ----------
+    name : str
+        Human-readable project name. Used in run identifiers (Phase 2) and
+        plan/manifest fingerprints.
+    default_storage : str | None
+        Default artifact/output storage URI (e.g. ``s3://bucket/runs/``,
+        ``/shared/scalable/runs``). Phase 1 records the value but does not
+        write to it; Phase 3 wires up the artifact backends.
+    local_cache : str | None
+        Per-project local cache path; complements the process-wide
+        :class:`scalable.common.Settings` cache directory.
+    """
+
+    name: str
+    default_storage: str | None = None
+    local_cache: str | None = None
+
+
+@dataclass(frozen=True)
+class TargetConfig:
+    """A named execution target that selects a deployment provider.
+
+    Attributes
+    ----------
+    name : str
+        The key under ``targets:`` in the manifest (e.g. ``"local"``,
+        ``"hpc"``, ``"gke"``).
+    provider : str
+        The :class:`~scalable.providers.base.DeploymentProvider` ``name``
+        attribute that handles this target. Phase 1 supports ``"local"``
+        and ``"slurm"``; later phases register additional providers.
+    options : Mapping[str, Any]
+        Provider-specific options (queue, account, walltime, namespace, ...).
+        Unknown keys are passed through to the provider and surfaced as
+        warnings rather than errors so Phase 1 manifests can carry
+        forward-compatible fields for Phase 3 cloud/k8s providers.
+    """
+
+    name: str
+    provider: str
+    options: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class ComponentConfig:
+    """A reusable container/runtime profile referenced by tasks and providers.
+
+    Maps directly onto the legacy ``add_container(tag=..., dirs=..., path=...,
+    cpus=..., memory=..., preload_script=...)`` call in
+    :class:`scalable.core.JobQueueCluster`. The manifest-to-legacy adapter
+    in :mod:`scalable.manifest.adapter` performs that translation in one
+    pure function so every provider shares it.
+
+    Attributes
+    ----------
+    name : str
+        The component key under ``components:`` in the manifest. This is
+        also the Dask resource ``tag`` used by
+        :meth:`scalable.client.ScalableClient.submit`.
+    image : str | None
+        Container image reference (e.g. ``ghcr.io/jgcri/scalable-gcam:7.0``).
+        Optional in Phase 1 ``local`` mode (``containers: none``).
+    runtime : str | None
+        Container runtime (``"apptainer"`` or ``"docker"``). When omitted,
+        the provider's default applies (``apptainer`` on Slurm, ``none``
+        on local).
+    cpus : int
+        CPU cores reserved per worker. Defaults to ``1``.
+    memory : str | None
+        Memory string parseable by :func:`dask.utils.parse_bytes`
+        (``"8G"``, ``"500MB"``, ``"20G"``).
+    mounts : Mapping[str, str]
+        Bind-mount mapping. Schema convention is ``{host_path:
+        container_path}`` (matches the example in the master plan); the
+        adapter normalises this to the legacy ``dirs`` argument expected by
+        :meth:`scalable.core.JobQueueCluster.add_container`.
+    env : Mapping[str, str]
+        Environment variables forwarded into the container at worker launch.
+    tags : list[str]
+        Free-form labels (``"iam"``, ``"climate"``, ``"compiled"``). Reserved
+        for Phase 4 AI assistants and Phase 2 telemetry filtering; not used
+        for routing in Phase 1.
+    preload_script : str | None
+        Optional Dask worker preload script path; passes through to
+        ``add_container(preload_script=...)``.
+    """
+
+    name: str
+    image: str | None = None
+    runtime: str | None = None
+    cpus: int = 1
+    memory: str | None = None
+    mounts: dict[str, str] = field(default_factory=dict)
+    env: dict[str, str] = field(default_factory=dict)
+    tags: list[str] = field(default_factory=list)
+    preload_script: str | None = None
+
+
+@dataclass(frozen=True)
+class TaskConfig:
+    """A logical task definition pinned to a component.
+
+    Phase 1 records task definitions but does not yet execute on them; the
+    dry-run planner uses them to size worker groups. Phase 4 AI planners
+    use this map to infer DAG structure.
+
+    Attributes
+    ----------
+    name : str
+        Task key under ``tasks:`` in the manifest.
+    component : str
+        Name of the :class:`ComponentConfig` this task runs in. Validated
+        for existence by :mod:`scalable.manifest.validate`.
+    cache : bool
+        Whether the task's results should be cached. Phase 1 honours this
+        flag only at the manifest level; Phase 2 wires it into the
+        :func:`scalable.caching.cacheable` decorator metadata, and Phase 3
+        extends it to remote artifact stores.
+    outputs : Mapping[str, str]
+        Declared outputs (``{"database": "dir"}``). Reserved for Phase 3
+        artifact tracking.
+    """
+
+    name: str
+    component: str
+    cache: bool = False
+    outputs: dict[str, str] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class ManifestModel:
+    """Parsed, validated representation of a ``scalable.yaml`` document.
+
+    Instances are immutable so the canonicalised JSON used for
+    ``manifest_lock`` (Phase 1 §3.3) is stable across the lifetime of a
+    :class:`scalable.session.ScalableSession`.
+
+    Attributes
+    ----------
+    version : int
+        Schema version (always equal to :data:`SCHEMA_VERSION` once parsed).
+    project : ProjectConfig
+        Project metadata block.
+    targets : Mapping[str, TargetConfig]
+        Named execution targets; the key matches ``TargetConfig.name``.
+    components : Mapping[str, ComponentConfig]
+        Component definitions; the key matches ``ComponentConfig.name``.
+    tasks : Mapping[str, TaskConfig]
+        Task definitions; the key matches ``TaskConfig.name``.
+    raw : Mapping[str, Any]
+        The raw, post-env-expansion document. Carried so providers can
+        introspect forward-compatible keys without losing fidelity, and so
+        Phase 2 telemetry can record the exact manifest a run was launched
+        from.
+    source_path : str | None
+        Filesystem path the manifest was loaded from, if any.
+    """
+
+    version: int
+    project: ProjectConfig
+    targets: dict[str, TargetConfig]
+    components: dict[str, ComponentConfig]
+    tasks: dict[str, TaskConfig]
+    raw: dict[str, Any]
+    source_path: str | None = None
+
+
+__all__ = [
+    "ComponentConfig",
+    "ManifestModel",
+    "ProjectConfig",
+    "SCHEMA_VERSION",
+    "TargetConfig",
+    "TaskConfig",
+]

--- a/scalable/manifest/validate.py
+++ b/scalable/manifest/validate.py
@@ -1,0 +1,199 @@
+"""Semantic validation for parsed ``scalable.yaml`` manifests.
+
+The parser in :mod:`scalable.manifest.parser` enforces structural schema
+shape (required keys, value types, known top-level fields). This module
+adds cross-field checks that require seeing the whole manifest at once,
+without coupling to provider implementations.
+
+Phase 1 checks:
+
+* every ``tasks[*].component`` exists in ``components``;
+* each target references a known provider name;
+* component mount paths are absolute on both host and container sides;
+* component memory strings are parseable by :func:`dask.utils.parse_bytes`.
+
+The return type is a structured report instead of exceptions so
+``scalable validate`` can print multiple issues in one run.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import PurePosixPath
+
+from dask.utils import parse_bytes
+
+from .schema import ManifestModel
+
+__all__ = [
+    "ValidationIssue",
+    "ValidationReport",
+    "validate_manifest",
+]
+
+
+@dataclass(frozen=True)
+class ValidationIssue:
+    """Single validation finding.
+
+    Attributes
+    ----------
+    path : str
+        Manifest path-ish location (e.g. ``targets.local.provider``).
+    message : str
+        Human-readable message.
+    code : str | None
+        Stable machine-readable code for tooling (optional in Phase 1).
+    """
+
+    path: str
+    message: str
+    code: str | None = None
+
+
+@dataclass
+class ValidationReport:
+    """Structured validation output consumed by CLI and session APIs."""
+
+    errors: list[ValidationIssue] = field(default_factory=list)
+    warnings: list[ValidationIssue] = field(default_factory=list)
+
+    @property
+    def ok(self) -> bool:
+        """Whether the manifest passed validation with no errors."""
+        return not self.errors
+
+
+def validate_manifest(
+    manifest: ManifestModel,
+    *,
+    known_providers: set[str] | None = None,
+) -> ValidationReport:
+    """Validate a parsed manifest and return a structured report.
+
+    Parameters
+    ----------
+    manifest : ManifestModel
+        Parsed model from :func:`scalable.manifest.parser.parse_manifest`.
+    known_providers : set[str] | None
+        Provider names accepted by this runtime. Defaults to
+        ``{"local", "slurm"}`` in Phase 1 and can be replaced by the
+        provider registry in WU-4.
+    """
+    report = ValidationReport()
+    providers = known_providers or {"local", "slurm"}
+
+    # ------------------------------------------------------------------
+    # Target/provider checks
+    # ------------------------------------------------------------------
+    if not manifest.targets:
+        report.warnings.append(
+            ValidationIssue(
+                path="targets",
+                message="no targets declared; session startup requires a target",
+                code="W_NO_TARGETS",
+            )
+        )
+    for target_name, target in manifest.targets.items():
+        if target.provider not in providers:
+            report.errors.append(
+                ValidationIssue(
+                    path=f"targets.{target_name}.provider",
+                    message=(
+                        f"unknown provider {target.provider!r}; "
+                        f"known providers: {sorted(providers)}"
+                    ),
+                    code="E_UNKNOWN_PROVIDER",
+                )
+            )
+
+    # ------------------------------------------------------------------
+    # Component checks
+    # ------------------------------------------------------------------
+    for component_name, component in manifest.components.items():
+        # Memory parseability (shape already type-checked by parser)
+        if component.memory is not None:
+            try:
+                parsed = parse_bytes(component.memory)
+            except Exception:
+                report.errors.append(
+                    ValidationIssue(
+                        path=f"components.{component_name}.memory",
+                        message=(
+                            f"memory value {component.memory!r} is not parseable; "
+                            "use values like '8G', '500MB', or '1024MiB'"
+                        ),
+                        code="E_BAD_MEMORY",
+                    )
+                )
+            else:
+                if parsed <= 0:
+                    report.errors.append(
+                        ValidationIssue(
+                            path=f"components.{component_name}.memory",
+                            message="memory must be greater than zero",
+                            code="E_NONPOSITIVE_MEMORY",
+                        )
+                    )
+
+        # Mount path absoluteness
+        for host_path, container_path in component.mounts.items():
+            if not _is_absolute_posix_like(host_path):
+                report.errors.append(
+                    ValidationIssue(
+                        path=f"components.{component_name}.mounts[{host_path!r}]",
+                        message="host mount path must be absolute",
+                        code="E_RELATIVE_HOST_MOUNT",
+                    )
+                )
+            if not _is_absolute_posix_like(container_path):
+                report.errors.append(
+                    ValidationIssue(
+                        path=(
+                            f"components.{component_name}.mounts"
+                            f"[{host_path!r}]"
+                        ),
+                        message="container mount path must be absolute",
+                        code="E_RELATIVE_CONTAINER_MOUNT",
+                    )
+                )
+
+    # ------------------------------------------------------------------
+    # Task/component cross references
+    # ------------------------------------------------------------------
+    known_components = set(manifest.components)
+    for task_name, task in manifest.tasks.items():
+        if task.component not in known_components:
+            report.errors.append(
+                ValidationIssue(
+                    path=f"tasks.{task_name}.component",
+                    message=(
+                        f"unknown component {task.component!r}; "
+                        f"known components: {sorted(known_components)}"
+                    ),
+                    code="E_UNKNOWN_COMPONENT",
+                )
+            )
+
+    if not manifest.tasks:
+        report.warnings.append(
+            ValidationIssue(
+                path="tasks",
+                message="no tasks declared; planning will produce an empty task set",
+                code="W_NO_TASKS",
+            )
+        )
+
+    return report
+
+
+def _is_absolute_posix_like(path: str) -> bool:
+    """Return whether a path is absolute in POSIX terms.
+
+    Manifest paths are provider/runtime-oriented (containers, Linux HPC,
+    object-store mount shims), so we normalize using POSIX semantics.
+    """
+    if not isinstance(path, str) or not path:
+        return False
+    return PurePosixPath(path).is_absolute()
+

--- a/scalable/planning/__init__.py
+++ b/scalable/planning/__init__.py
@@ -13,4 +13,6 @@ test-pinned so Phase 2 telemetry can durably reference manifests.
 
 from __future__ import annotations
 
-__all__: list[str] = []
+from .dryrun import DryRunPlan, build_dry_run_plan, compute_manifest_lock
+
+__all__ = ["DryRunPlan", "build_dry_run_plan", "compute_manifest_lock"]

--- a/scalable/planning/__init__.py
+++ b/scalable/planning/__init__.py
@@ -1,0 +1,16 @@
+"""Plan and dry-run primitives (v2.0.0 Phase 1).
+
+Phase 1 ships a deterministic dry-run planner that converts a
+:class:`~scalable.manifest.schema.ManifestModel` plus a target into a
+provider-neutral :class:`~scalable.providers.base.ScalePlan` plus a
+``manifest_lock`` SHA-256 fingerprint. No workers are launched.
+
+Phase 4 plugs the AI workflow planner in here (objective/policy-driven
+plan synthesis); Phase 5 layers an ML-trained resource advisor on top.
+The Phase 1 ``manifest_lock`` canonicalisation rules are documented and
+test-pinned so Phase 2 telemetry can durably reference manifests.
+"""
+
+from __future__ import annotations
+
+__all__: list[str] = []

--- a/scalable/planning/dryrun.py
+++ b/scalable/planning/dryrun.py
@@ -1,0 +1,90 @@
+"""Deterministic dry-run planning primitives (Phase 1 WU-9)."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from typing import Any
+
+from scalable.providers.base import DeploymentSpec, ResourceRequest, ScalePlan
+
+__all__ = [
+    "DryRunPlan",
+    "build_dry_run_plan",
+    "compute_manifest_lock",
+]
+
+
+@dataclass(frozen=True)
+class DryRunPlan:
+    """Serializable dry-run result for CLI/session APIs."""
+
+    target_name: str
+    provider_name: str
+    manifest_lock: str
+    scale_plan: ScalePlan
+    task_to_component: dict[str, str]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "version": 1,
+            "target": self.target_name,
+            "provider": self.provider_name,
+            "manifest_lock": self.manifest_lock,
+            "task_to_component": dict(self.task_to_component),
+            "scale_plan": {
+                "workers_by_tag": dict(self.scale_plan.workers_by_tag),
+                "resources_by_tag": {
+                    tag: {
+                        "cpus": req.cpus,
+                        "memory": req.memory,
+                        "walltime": req.walltime,
+                        "gpus": req.gpus,
+                    }
+                    for tag, req in self.scale_plan.resources_by_tag.items()
+                },
+            },
+        }
+
+
+def compute_manifest_lock(raw_manifest: dict[str, Any]) -> str:
+    """Compute deterministic SHA-256 fingerprint of canonicalized manifest."""
+    canonical = json.dumps(raw_manifest, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def build_dry_run_plan(spec: DeploymentSpec) -> DryRunPlan:
+    """Build a deterministic provider-neutral dry-run plan from spec."""
+    task_to_component = {task_name: task.component for task_name, task in spec.tasks.items()}
+
+    # Start from task usage so only referenced components are scaled by default.
+    referenced_components = {task.component for task in spec.tasks.values()}
+
+    workers_by_tag: dict[str, int] = {}
+    resources_by_tag: dict[str, ResourceRequest] = {}
+    walltime = spec.target.options.get("walltime")
+
+    for component_name in sorted(referenced_components):
+        component = spec.components[component_name]
+        workers_by_tag[component_name] = 1
+        resources_by_tag[component_name] = ResourceRequest(
+            cpus=component.cpus,
+            memory=component.memory,
+            walltime=walltime if isinstance(walltime, str) else None,
+            gpus=None,
+        )
+
+    scale_plan = ScalePlan(
+        workers_by_tag=workers_by_tag,
+        resources_by_tag=resources_by_tag,
+    )
+
+    return DryRunPlan(
+        target_name=spec.target_name,
+        provider_name=spec.provider_name,
+        manifest_lock=compute_manifest_lock(spec.raw_manifest),
+        scale_plan=scale_plan,
+        task_to_component=task_to_component,
+    )
+

--- a/scalable/providers/__init__.py
+++ b/scalable/providers/__init__.py
@@ -28,6 +28,7 @@ from .registry import (
     register_provider,
     register_providers,
 )
+from .slurm import SlurmProvider
 
 __all__ = [
     "ClusterHandle",
@@ -36,6 +37,7 @@ __all__ = [
     "LocalProvider",
     "ResourceRequest",
     "ScalePlan",
+    "SlurmProvider",
     "clear_registry",
     "get_provider",
     "iter_provider_names",

--- a/scalable/providers/__init__.py
+++ b/scalable/providers/__init__.py
@@ -19,4 +19,24 @@ Slurm-specific fields so AI planners (Phase 4) and ML resource advisors
 
 from __future__ import annotations
 
-__all__: list[str] = []
+from .base import ClusterHandle, DeploymentProvider, DeploymentSpec, ResourceRequest, ScalePlan
+from .registry import (
+    clear_registry,
+    get_provider,
+    iter_provider_names,
+    register_provider,
+    register_providers,
+)
+
+__all__ = [
+    "ClusterHandle",
+    "DeploymentProvider",
+    "DeploymentSpec",
+    "ResourceRequest",
+    "ScalePlan",
+    "clear_registry",
+    "get_provider",
+    "iter_provider_names",
+    "register_provider",
+    "register_providers",
+]

--- a/scalable/providers/__init__.py
+++ b/scalable/providers/__init__.py
@@ -1,0 +1,22 @@
+"""Deployment provider layer (v2.0.0 Phase 1).
+
+A :class:`~scalable.providers.base.DeploymentProvider` is the seam between
+the declarative :class:`~scalable.manifest.schema.ManifestModel` and a
+concrete Dask cluster backend. Phase 1 ships:
+
+* :class:`~scalable.providers.local.LocalProvider` -- Dask ``LocalCluster``
+  for laptops and CI.
+* :class:`~scalable.providers.slurm.SlurmProvider` -- adapter around the
+  existing :class:`scalable.slurm.SlurmCluster` HPC path.
+
+Phase 3 will register :class:`KubernetesProvider`, :class:`CloudProvider`,
+and :class:`StaticProvider` against the same protocol via the registry's
+``entry_points("scalable.providers")`` hook (see
+:mod:`scalable.providers.registry`). The protocol is intentionally free of
+Slurm-specific fields so AI planners (Phase 4) and ML resource advisors
+(Phase 5) can operate on a provider-neutral plan.
+"""
+
+from __future__ import annotations
+
+__all__: list[str] = []

--- a/scalable/providers/__init__.py
+++ b/scalable/providers/__init__.py
@@ -20,6 +20,7 @@ Slurm-specific fields so AI planners (Phase 4) and ML resource advisors
 from __future__ import annotations
 
 from .base import ClusterHandle, DeploymentProvider, DeploymentSpec, ResourceRequest, ScalePlan
+from .local import LocalProvider
 from .registry import (
     clear_registry,
     get_provider,
@@ -32,6 +33,7 @@ __all__ = [
     "ClusterHandle",
     "DeploymentProvider",
     "DeploymentSpec",
+    "LocalProvider",
     "ResourceRequest",
     "ScalePlan",
     "clear_registry",

--- a/scalable/providers/base.py
+++ b/scalable/providers/base.py
@@ -1,0 +1,134 @@
+"""Provider protocol and core provider-neutral data structures.
+
+Phase 1 introduces an explicit deployment seam so Scalable can target local,
+Slurm, Kubernetes, and cloud backends through one stable contract.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import Any, Protocol
+
+from scalable.client import ScalableClient
+from scalable.manifest.schema import (
+    ComponentConfig,
+    ManifestModel,
+    TargetConfig,
+    TaskConfig,
+)
+from scalable.manifest.validate import ValidationReport
+
+__all__ = [
+    "ClusterHandle",
+    "DeploymentProvider",
+    "DeploymentSpec",
+    "ResourceRequest",
+    "ScalePlan",
+]
+
+
+@dataclass(frozen=True)
+class DeploymentSpec:
+    """Provider-neutral deployment request derived from a manifest target.
+
+    Attributes
+    ----------
+    target_name
+        Name under ``targets:`` selected by the caller.
+    provider_name
+        Provider identifier from ``targets.<name>.provider``.
+    manifest
+        Full parsed manifest model.
+    target
+        Target block selected from the manifest.
+    components
+        Components map copied from the manifest.
+    tasks
+        Tasks map copied from the manifest.
+    raw_manifest
+        Expanded raw manifest data used for deterministic fingerprinting.
+    """
+
+    target_name: str
+    provider_name: str
+    manifest: ManifestModel
+    target: TargetConfig
+    components: dict[str, ComponentConfig]
+    tasks: dict[str, TaskConfig]
+    raw_manifest: dict[str, Any]
+
+    @classmethod
+    def from_manifest(
+        cls,
+        manifest: ManifestModel,
+        *,
+        target_name: str,
+    ) -> DeploymentSpec:
+        """Build a :class:`DeploymentSpec` from a parsed manifest.
+
+        Raises
+        ------
+        KeyError
+            If ``target_name`` is not present in ``manifest.targets``.
+        """
+        target = manifest.targets[target_name]
+        return cls(
+            target_name=target_name,
+            provider_name=target.provider,
+            manifest=manifest,
+            target=target,
+            components=dict(manifest.components),
+            tasks=dict(manifest.tasks),
+            raw_manifest=dict(manifest.raw),
+        )
+
+
+@dataclass(frozen=True)
+class ResourceRequest:
+    """Resource request for one worker group/tag."""
+
+    cpus: int = 1
+    memory: str | None = None
+    walltime: str | None = None
+    gpus: int | None = None
+
+
+@dataclass(frozen=True)
+class ScalePlan:
+    """Provider-neutral scaling intent generated from the manifest."""
+
+    workers_by_tag: dict[str, int] = field(default_factory=dict)
+    resources_by_tag: dict[str, ResourceRequest] = field(default_factory=dict)
+
+
+@dataclass
+class ClusterHandle:
+    """Opaque holder for provider-specific cluster state.
+
+    Providers return this instead of raw cluster objects so higher layers can
+    remain provider-neutral while still creating :class:`ScalableClient`
+    instances through ``client_factory``.
+    """
+
+    backend: Any
+    client_factory: Callable[[], ScalableClient]
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+class DeploymentProvider(Protocol):
+    """Protocol implemented by all execution providers."""
+
+    name: str
+
+    def validate(self, spec: DeploymentSpec) -> ValidationReport:
+        """Validate provider-specific options and constraints."""
+
+    def build_cluster(self, spec: DeploymentSpec) -> ClusterHandle:
+        """Create or connect to a backend cluster and return a handle."""
+
+    def scale(self, cluster: ClusterHandle, plan: ScalePlan) -> None:
+        """Apply scaling operations for this provider."""
+
+    def close(self, cluster: ClusterHandle) -> None:
+        """Close provider-managed resources."""

--- a/scalable/providers/local.py
+++ b/scalable/providers/local.py
@@ -1,0 +1,169 @@
+"""Local provider implementation for laptops/CI (Phase 1 WU-5)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from distributed import LocalCluster
+
+from scalable.client import ScalableClient
+from scalable.manifest.validate import ValidationIssue, ValidationReport, validate_manifest
+
+from .base import ClusterHandle, DeploymentProvider, DeploymentSpec, ScalePlan
+
+__all__ = ["LocalProvider"]
+
+
+class LocalProvider(DeploymentProvider):
+    """Run Scalable workloads on a local Dask cluster.
+
+    Phase 1 scope:
+    - deterministic local execution for development and CI,
+    - tag-aware worker resources compatible with
+      :meth:`scalable.client.ScalableClient.submit(..., tag=...)`,
+    - no container runtime orchestration beyond validating option flags.
+    """
+
+    name = "local"
+
+    _ALLOWED_CONTAINER_MODES = {"none", "auto", "docker"}
+
+    def validate(self, spec: DeploymentSpec) -> ValidationReport:
+        report = validate_manifest(spec.manifest, known_providers={"local", "slurm"})
+        options = spec.target.options
+
+        if "max_workers" in options:
+            max_workers = options["max_workers"]
+            if (
+                not isinstance(max_workers, int)
+                or isinstance(max_workers, bool)
+                or max_workers < 1
+            ):
+                report.errors.append(
+                    ValidationIssue(
+                        path=f"targets.{spec.target_name}.max_workers",
+                        message="max_workers must be a positive integer",
+                        code="E_BAD_MAX_WORKERS",
+                    )
+                )
+
+        if "threads_per_worker" in options:
+            threads = options["threads_per_worker"]
+            if not isinstance(threads, int) or isinstance(threads, bool) or threads < 1:
+                report.errors.append(
+                    ValidationIssue(
+                        path=f"targets.{spec.target_name}.threads_per_worker",
+                        message="threads_per_worker must be a positive integer",
+                        code="E_BAD_THREADS_PER_WORKER",
+                    )
+                )
+
+        if "processes" in options and not isinstance(options["processes"], bool):
+            report.errors.append(
+                ValidationIssue(
+                    path=f"targets.{spec.target_name}.processes",
+                    message="processes must be a boolean",
+                    code="E_BAD_PROCESSES_FLAG",
+                )
+            )
+
+        containers_mode = options.get("containers", "none")
+        if not isinstance(containers_mode, str):
+            report.errors.append(
+                ValidationIssue(
+                    path=f"targets.{spec.target_name}.containers",
+                    message="containers must be one of: none, auto, docker",
+                    code="E_BAD_CONTAINERS_MODE",
+                )
+            )
+        else:
+            normalized = containers_mode.strip().lower()
+            if normalized not in self._ALLOWED_CONTAINER_MODES:
+                report.errors.append(
+                    ValidationIssue(
+                        path=f"targets.{spec.target_name}.containers",
+                        message=(
+                            f"unsupported containers mode {containers_mode!r}; "
+                            f"allowed values: {sorted(self._ALLOWED_CONTAINER_MODES)}"
+                        ),
+                        code="E_BAD_CONTAINERS_MODE",
+                    )
+                )
+            elif normalized in {"auto", "docker"}:
+                report.warnings.append(
+                    ValidationIssue(
+                        path=f"targets.{spec.target_name}.containers",
+                        message=(
+                            "container orchestration in LocalProvider is deferred; "
+                            "Phase 1 runs in no-container mode"
+                        ),
+                        code="W_LOCAL_CONTAINERS_DEFERRED",
+                    )
+                )
+
+        return report
+
+    def build_cluster(self, spec: DeploymentSpec) -> ClusterHandle:
+        validation = self.validate(spec)
+        if not validation.ok:
+            details = "; ".join(
+                f"{issue.path}: {issue.message}" for issue in validation.errors
+            )
+            raise ValueError(f"invalid local deployment spec: {details}")
+
+        options = spec.target.options
+        # Default worker count: one worker per component, minimum one.
+        default_workers = max(1, len(spec.components))
+        n_workers = int(options.get("max_workers", default_workers))
+        threads_per_worker = int(options.get("threads_per_worker", 1))
+        processes = bool(options.get("processes", False))
+        dashboard_address = options.get("dashboard_address")
+
+        # Preserve tag routing semantics from ScalableClient.submit(tag=...):
+        # every worker advertises every component tag with 1 unit.
+        worker_resources = {component_name: 1 for component_name in spec.components}
+
+        cluster = LocalCluster(
+            n_workers=n_workers,
+            threads_per_worker=threads_per_worker,
+            processes=processes,
+            scheduler_port=0,
+            dashboard_address=dashboard_address,
+            silence_logs="error",
+            resources=worker_resources,
+        )
+
+        def _client_factory() -> ScalableClient:
+            return ScalableClient(cluster)
+
+        return ClusterHandle(
+            backend=cluster,
+            client_factory=_client_factory,
+            metadata={
+                "provider": self.name,
+                "target": spec.target_name,
+                "n_workers": n_workers,
+                "threads_per_worker": threads_per_worker,
+                "processes": processes,
+                "worker_resources": worker_resources,
+            },
+        )
+
+    def scale(self, cluster: ClusterHandle, plan: ScalePlan) -> None:
+        backend = cluster.backend
+        if not hasattr(backend, "scale"):
+            raise TypeError("cluster backend does not support scale()")
+
+        if plan.workers_by_tag:
+            target_workers = sum(max(int(n), 0) for n in plan.workers_by_tag.values())
+            backend.scale(target_workers)
+
+    def close(self, cluster: ClusterHandle) -> None:
+        backend = cluster.backend
+        if hasattr(backend, "close"):
+            backend.close()
+
+
+def _debug_options_snapshot(options: dict[str, Any]) -> dict[str, Any]:
+    """Return a stable options snapshot for debugging/tests if needed."""
+    return {k: options[k] for k in sorted(options)}

--- a/scalable/providers/registry.py
+++ b/scalable/providers/registry.py
@@ -51,6 +51,11 @@ def get_provider(name: str) -> DeploymentProvider:
     if normalized in _REGISTRY:
         return _instantiate(_REGISTRY[normalized])
 
+    builtin = _load_builtin_provider(normalized)
+    if builtin is not None:
+        _REGISTRY[normalized] = builtin
+        return _instantiate(builtin)
+
     discovered = _load_provider_entrypoint(normalized)
     if discovered is None:
         known = sorted(iter_provider_names(include_entrypoints=True))
@@ -119,3 +124,18 @@ def _load_provider_entrypoint(name: str) -> ProviderFactory | None:
         )
     return None
 
+
+def _load_builtin_provider(name: str) -> ProviderFactory | None:
+    """Load built-in providers lazily to avoid import-order cycles."""
+    normalized = _normalize_provider_name(name)
+    if normalized == "local":
+        from .local import LocalProvider
+
+        return LocalProvider
+    if normalized == "slurm":
+        try:
+            from .slurm import SlurmProvider
+        except ImportError:
+            return None
+        return SlurmProvider
+    return None

--- a/scalable/providers/registry.py
+++ b/scalable/providers/registry.py
@@ -1,0 +1,121 @@
+"""Provider registry and discovery helpers.
+
+Phase 1 supports built-in providers (`local`, `slurm`) and allows optional
+third-party provider registration through Python entry points under the
+``scalable.providers`` group.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable
+from importlib.metadata import EntryPoint, entry_points
+from typing import Any
+
+from .base import DeploymentProvider
+
+ProviderFactory = Callable[[], DeploymentProvider] | type[DeploymentProvider]
+
+_REGISTRY: dict[str, ProviderFactory] = {}
+
+__all__ = [
+    "clear_registry",
+    "get_provider",
+    "iter_provider_names",
+    "register_provider",
+    "register_providers",
+]
+
+
+def register_provider(name: str, factory: ProviderFactory) -> None:
+    """Register a provider factory/class under a stable name."""
+    normalized = _normalize_provider_name(name)
+    if normalized in _REGISTRY:
+        raise ValueError(f"provider {normalized!r} is already registered")
+    _REGISTRY[normalized] = factory
+
+
+def register_providers(items: Iterable[tuple[str, ProviderFactory]]) -> None:
+    """Bulk register provider factories."""
+    for name, factory in items:
+        register_provider(name, factory)
+
+
+def get_provider(name: str) -> DeploymentProvider:
+    """Resolve and instantiate a provider by name.
+
+    Lookup order:
+    1. Explicit runtime registry (`register_provider`).
+    2. Entry points in group ``scalable.providers``.
+    """
+    normalized = _normalize_provider_name(name)
+    if normalized in _REGISTRY:
+        return _instantiate(_REGISTRY[normalized])
+
+    discovered = _load_provider_entrypoint(normalized)
+    if discovered is None:
+        known = sorted(iter_provider_names(include_entrypoints=True))
+        raise KeyError(
+            f"unknown provider {normalized!r}; known providers: {known}"
+        )
+    # Cache discovered providers for next lookup.
+    _REGISTRY[normalized] = discovered
+    return _instantiate(discovered)
+
+
+def iter_provider_names(*, include_entrypoints: bool = True) -> set[str]:
+    """Return provider names known to the runtime."""
+    names = set(_REGISTRY)
+    if include_entrypoints:
+        for ep in _iter_provider_entrypoints():
+            names.add(_normalize_provider_name(ep.name))
+    return names
+
+
+def clear_registry() -> None:
+    """Reset runtime registrations (primarily for tests)."""
+    _REGISTRY.clear()
+
+
+def _normalize_provider_name(name: str) -> str:
+    normalized = name.strip().lower()
+    if not normalized:
+        raise ValueError("provider name must be a non-empty string")
+    return normalized
+
+
+def _instantiate(factory: ProviderFactory) -> DeploymentProvider:
+    if isinstance(factory, type):
+        return factory()
+    return factory()
+
+
+def _iter_provider_entrypoints() -> list[EntryPoint]:
+    try:
+        eps = entry_points(group="scalable.providers")
+        # Python 3.12+ returns EntryPoints object; convert to list.
+        return list(eps)
+    except TypeError:
+        # Compatibility for older return style where group is filtered via
+        # select(). Retained for robustness.
+        eps = entry_points()
+        selected = getattr(eps, "select", None)
+        if callable(selected):
+            return list(selected(group="scalable.providers"))
+        return [ep for ep in eps if getattr(ep, "group", None) == "scalable.providers"]
+
+
+def _load_provider_entrypoint(name: str) -> ProviderFactory | None:
+    normalized = _normalize_provider_name(name)
+    for ep in _iter_provider_entrypoints():
+        if _normalize_provider_name(ep.name) != normalized:
+            continue
+        loaded: Any = ep.load()
+        if isinstance(loaded, type):
+            return loaded
+        if callable(loaded):
+            return loaded
+        raise TypeError(
+            f"entry point scalable.providers:{ep.name} must load a class or callable"
+        )
+    return None
+

--- a/scalable/providers/slurm.py
+++ b/scalable/providers/slurm.py
@@ -1,0 +1,183 @@
+"""Slurm provider implementation (Phase 1 WU-6).
+
+This provider is intentionally a thin translation layer over the existing
+``scalable.slurm.SlurmCluster`` path so Phase 1 can ship provider abstraction
+without regressing established HPC behavior.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+
+from scalable.manifest.validate import ValidationIssue, ValidationReport, validate_manifest
+from scalable.slurm import SlurmCluster
+
+from .base import ClusterHandle, DeploymentProvider, DeploymentSpec, ScalePlan
+
+__all__ = ["SlurmProvider"]
+
+_WALLTIME_RE = re.compile(r"^\d{1,3}:\d{2}:\d{2}$")
+
+
+class SlurmProvider(DeploymentProvider):
+    """Provider wrapper over :class:`scalable.slurm.SlurmCluster`."""
+
+    name = "slurm"
+
+    def validate(self, spec: DeploymentSpec) -> ValidationReport:
+        report = validate_manifest(spec.manifest, known_providers={"local", "slurm"})
+        options = spec.target.options
+
+        _require_type(report, spec.target_name, options, "queue", str)
+        _require_type(report, spec.target_name, options, "account", str)
+        _require_type(report, spec.target_name, options, "interface", str)
+        _require_type(report, spec.target_name, options, "logs_location", str)
+        _require_type(report, spec.target_name, options, "name", str)
+
+        if "suppress_logs" in options and not isinstance(options["suppress_logs"], bool):
+            report.errors.append(
+                ValidationIssue(
+                    path=f"targets.{spec.target_name}.suppress_logs",
+                    message="suppress_logs must be a boolean",
+                    code="E_BAD_SUPPRESS_LOGS",
+                )
+            )
+
+        if "walltime" in options:
+            walltime = options["walltime"]
+            if not isinstance(walltime, str) or not _WALLTIME_RE.match(walltime):
+                report.errors.append(
+                    ValidationIssue(
+                        path=f"targets.{spec.target_name}.walltime",
+                        message="walltime must be a string in HH:MM:SS format",
+                        code="E_BAD_WALLTIME",
+                    )
+                )
+
+        if "comm_port" in options:
+            comm_port = options["comm_port"]
+            if not isinstance(comm_port, int) or isinstance(comm_port, bool) or comm_port <= 0:
+                report.errors.append(
+                    ValidationIssue(
+                        path=f"targets.{spec.target_name}.comm_port",
+                        message="comm_port must be a positive integer",
+                        code="E_BAD_COMM_PORT",
+                    )
+                )
+        else:
+            if os.environ.get("COMM_PORT") is None:
+                report.errors.append(
+                    ValidationIssue(
+                        path=f"targets.{spec.target_name}.comm_port",
+                        message=(
+                            "comm_port is required for SlurmProvider (set it in manifest "
+                            "or via COMM_PORT environment variable)"
+                        ),
+                        code="E_MISSING_COMM_PORT",
+                    )
+                )
+
+        if "container_runtime" in options:
+            runtime = options["container_runtime"]
+            if not isinstance(runtime, str):
+                report.errors.append(
+                    ValidationIssue(
+                        path=f"targets.{spec.target_name}.container_runtime",
+                        message="container_runtime must be a string",
+                        code="E_BAD_CONTAINER_RUNTIME",
+                    )
+                )
+            else:
+                normalized = runtime.strip().lower()
+                if normalized not in {"apptainer", "docker"}:
+                    report.errors.append(
+                        ValidationIssue(
+                            path=f"targets.{spec.target_name}.container_runtime",
+                            message="container_runtime must be either 'apptainer' or 'docker'",
+                            code="E_BAD_CONTAINER_RUNTIME",
+                        )
+                    )
+
+        return report
+
+    def build_cluster(self, spec: DeploymentSpec) -> ClusterHandle:
+        validation = self.validate(spec)
+        if not validation.ok:
+            details = "; ".join(
+                f"{issue.path}: {issue.message}" for issue in validation.errors
+            )
+            raise ValueError(f"invalid slurm deployment spec: {details}")
+
+        options = spec.target.options
+        cluster_kwargs = {
+            "queue": options.get("queue"),
+            "account": options.get("account"),
+            "walltime": options.get("walltime"),
+            "interface": options.get("interface"),
+            "name": options.get("name"),
+            "logs_location": options.get("logs_location"),
+            "suppress_logs": options.get("suppress_logs", False),
+        }
+        if "comm_port" in options:
+            cluster_kwargs["comm_port"] = options["comm_port"]
+
+        cluster = SlurmCluster(**cluster_kwargs)
+
+        for component_name, component in spec.components.items():
+            cluster.add_container(
+                tag=component_name,
+                dirs=dict(component.mounts),
+                path=component.image,
+                cpus=component.cpus,
+                memory=component.memory,
+                preload_script=component.preload_script,
+            )
+
+        def _client_factory():
+            from scalable.client import ScalableClient
+
+            return ScalableClient(cluster)
+
+        return ClusterHandle(
+            backend=cluster,
+            client_factory=_client_factory,
+            metadata={
+                "provider": self.name,
+                "target": spec.target_name,
+                "cluster_kwargs": {k: v for k, v in cluster_kwargs.items() if v is not None},
+            },
+        )
+
+    def scale(self, cluster: ClusterHandle, plan: ScalePlan) -> None:
+        backend = cluster.backend
+        if not hasattr(backend, "add_workers"):
+            raise TypeError("cluster backend does not support add_workers()")
+
+        for tag, count in plan.workers_by_tag.items():
+            n = int(count)
+            if n > 0:
+                backend.add_workers(tag=tag, n=n)
+
+    def close(self, cluster: ClusterHandle) -> None:
+        backend = cluster.backend
+        if hasattr(backend, "close"):
+            backend.close()
+
+
+def _require_type(
+    report: ValidationReport,
+    target_name: str,
+    options: dict,
+    key: str,
+    expected_type: type,
+) -> None:
+    if key in options and not isinstance(options[key], expected_type):
+        report.errors.append(
+            ValidationIssue(
+                path=f"targets.{target_name}.{key}",
+                message=f"{key} must be a {expected_type.__name__}",
+                code=f"E_BAD_{key.upper()}",
+            )
+        )
+

--- a/scalable/providers/slurm.py
+++ b/scalable/providers/slurm.py
@@ -10,6 +10,11 @@ from __future__ import annotations
 import os
 import re
 
+from scalable.manifest.adapter import (
+    add_components_to_legacy_cluster,
+    build_slurm_cluster_kwargs,
+    create_legacy_slurm_cluster,
+)
 from scalable.manifest.validate import ValidationIssue, ValidationReport, validate_manifest
 from scalable.slurm import SlurmCluster
 
@@ -109,30 +114,9 @@ class SlurmProvider(DeploymentProvider):
             )
             raise ValueError(f"invalid slurm deployment spec: {details}")
 
-        options = spec.target.options
-        cluster_kwargs = {
-            "queue": options.get("queue"),
-            "account": options.get("account"),
-            "walltime": options.get("walltime"),
-            "interface": options.get("interface"),
-            "name": options.get("name"),
-            "logs_location": options.get("logs_location"),
-            "suppress_logs": options.get("suppress_logs", False),
-        }
-        if "comm_port" in options:
-            cluster_kwargs["comm_port"] = options["comm_port"]
-
-        cluster = SlurmCluster(**cluster_kwargs)
-
-        for component_name, component in spec.components.items():
-            cluster.add_container(
-                tag=component_name,
-                dirs=dict(component.mounts),
-                path=component.image,
-                cpus=component.cpus,
-                memory=component.memory,
-                preload_script=component.preload_script,
-            )
+        cluster_kwargs = build_slurm_cluster_kwargs(spec)
+        cluster = create_legacy_slurm_cluster(spec, cluster_cls=SlurmCluster)
+        add_components_to_legacy_cluster(spec, cluster)
 
         def _client_factory():
             from scalable.client import ScalableClient
@@ -180,4 +164,3 @@ def _require_type(
                 code=f"E_BAD_{key.upper()}",
             )
         )
-

--- a/scalable/session/__init__.py
+++ b/scalable/session/__init__.py
@@ -1,0 +1,13 @@
+"""Top-level ``ScalableSession`` user entry point (v2.0.0 Phase 1).
+
+:class:`~scalable.session.session.ScalableSession` is the public face of
+the v2.0.0 API surface advertised in the master plan
+(``ScalableSession.from_yaml(...)``, ``session.plan(...)``,
+``session.start(...)``). Phase 1 ships a minimal deterministic
+implementation; Phases 2-5 layer telemetry, AI planning, and ML resource
+advice onto the same surface without breaking the constructor signatures.
+"""
+
+from __future__ import annotations
+
+__all__: list[str] = []

--- a/scalable/session/__init__.py
+++ b/scalable/session/__init__.py
@@ -10,4 +10,6 @@ advice onto the same surface without breaking the constructor signatures.
 
 from __future__ import annotations
 
-__all__: list[str] = []
+from .session import ScalableSession
+
+__all__ = ["ScalableSession"]

--- a/scalable/session/session.py
+++ b/scalable/session/session.py
@@ -1,0 +1,158 @@
+"""ScalableSession implementation (Phase 1 WU-8)."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Any
+
+from scalable.client import ScalableClient
+from scalable.common import settings
+from scalable.manifest.parser import load_manifest
+from scalable.manifest.schema import ManifestModel
+from scalable.manifest.validate import ValidationIssue, ValidationReport, validate_manifest
+from scalable.planning.dryrun import DryRunPlan, build_dry_run_plan
+from scalable.providers.base import ClusterHandle, DeploymentSpec
+from scalable.providers.registry import get_provider, iter_provider_names
+
+__all__ = ["ScalableSession"]
+
+
+@dataclass
+class ScalableSession:
+    """Session lifecycle wrapper for manifest-driven execution."""
+
+    manifest: ManifestModel
+    target_name: str
+    spec: DeploymentSpec
+
+    _provider: Any = None
+    _cluster: ClusterHandle | None = None
+    _client: ScalableClient | None = None
+
+    @classmethod
+    def from_yaml(
+        cls,
+        path: str | os.PathLike[str] | None = None,
+        *,
+        target: str | None = None,
+    ) -> ScalableSession:
+        manifest_path = str(path or settings.manifest_path)
+        manifest = load_manifest(manifest_path)
+        selected_target = _resolve_target_name(manifest, requested=target)
+        spec = DeploymentSpec.from_manifest(manifest, target_name=selected_target)
+        return cls(manifest=manifest, target_name=selected_target, spec=spec)
+
+    def validate(self) -> ValidationReport:
+        known = set(iter_provider_names(include_entrypoints=True))
+        # Keep built-ins discoverable even before first runtime lookup.
+        known.update({"local", "slurm"})
+        report = validate_manifest(self.manifest, known_providers=known)
+
+        try:
+            provider = get_provider(self.spec.provider_name)
+        except KeyError as exc:
+            report.errors.append(
+                ValidationIssue(
+                    path=f"targets.{self.target_name}.provider",
+                    message=str(exc),
+                    code="E_UNKNOWN_PROVIDER",
+                )
+            )
+            return report
+
+        preport = provider.validate(self.spec)
+        report.errors.extend(preport.errors)
+        report.warnings.extend(preport.warnings)
+        return report
+
+    def plan(
+        self,
+        *,
+        dry_run: bool = False,
+        objective: str | None = None,
+        policy: str | None = None,
+    ) -> DryRunPlan:
+        if objective is not None or policy is not None:
+            raise NotImplementedError(
+                "objective/policy planning is planned for later phases; "
+                "Phase 1 supports deterministic dry-run planning only"
+            )
+
+        _ = dry_run  # Phase 1 currently only supports dry-run behavior.
+
+        report = self.validate()
+        if not report.ok:
+            details = "; ".join(f"{i.path}: {i.message}" for i in report.errors)
+            raise ValueError(f"manifest validation failed: {details}")
+
+        return build_dry_run_plan(self.spec)
+
+    def start(self, plan: DryRunPlan | None = None) -> ScalableClient:
+        if self._client is not None:
+            return self._client
+
+        if plan is None:
+            plan = self.plan(dry_run=True)
+        elif plan.target_name != self.target_name:
+            raise ValueError(
+                f"plan target {plan.target_name!r} does not match session target {self.target_name!r}"
+            )
+
+        self._provider = get_provider(self.spec.provider_name)
+        self._cluster = self._provider.build_cluster(self.spec)
+        self._provider.scale(self._cluster, plan.scale_plan)
+        self._client = self._cluster.client_factory()
+        return self._client
+
+    def close(self) -> None:
+        if self._client is not None:
+            self._client.close()
+            self._client = None
+
+        if self._cluster is not None and self._provider is not None:
+            self._provider.close(self._cluster)
+            self._cluster = None
+
+    def __enter__(self) -> ScalableClient:
+        return self.start()
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        self.close()
+
+
+def _resolve_target_name(manifest: ManifestModel, *, requested: str | None) -> str:
+    """Resolve session target from explicit input, settings, or auto mode."""
+    if not manifest.targets:
+        raise ValueError("manifest declares no targets")
+
+    desired = requested if requested is not None else settings.target
+    desired = desired or "auto"
+
+    if desired != "auto":
+        if desired not in manifest.targets:
+            raise KeyError(
+                f"target {desired!r} not found in manifest; available targets: "
+                f"{sorted(manifest.targets)}"
+            )
+        return desired
+
+    # Auto-resolution heuristic for Phase 1.
+    running_in_slurm = bool(os.environ.get("SLURM_JOB_ID") or os.environ.get("SLURM_CLUSTER_NAME"))
+    if running_in_slurm:
+        # Prefer target key named "slurm" then any target using slurm provider.
+        if "slurm" in manifest.targets:
+            return "slurm"
+        for tname, tcfg in manifest.targets.items():
+            if tcfg.provider == "slurm":
+                return tname
+
+    # Prefer target key named "local" then any target using local provider.
+    if "local" in manifest.targets:
+        return "local"
+    for tname, tcfg in manifest.targets.items():
+        if tcfg.provider == "local":
+            return tname
+
+    # Fallback: deterministic first key order from parsed mapping.
+    return next(iter(manifest.targets.keys()))

--- a/scalable/utilities.py
+++ b/scalable/utilities.py
@@ -5,6 +5,7 @@ import sys
 import threading
 import warnings
 from collections.abc import Mapping
+from contextlib import contextmanager
 from importlib.resources import files
 from typing import Any
 
@@ -14,6 +15,29 @@ from dask.utils import parse_bytes
 from .common import logger
 
 comm_port_regex = r'0\.0\.0\.0:(\d{1,5})'
+
+# Set to True when legacy ModelConfig initialization is invoked via the
+# manifest adapter/provider compatibility path. Direct user calls remain
+# deprecated and emit DeprecationWarning.
+_MODELCONFIG_ADAPTER_CONTEXT: bool = False
+
+
+@contextmanager
+def model_config_adapter_context() -> Any:
+    """Temporarily suppress ModelConfig deprecation warnings.
+
+    This context is used by the manifest-to-legacy adapter path introduced in
+    Phase 1. Direct usage of :class:`ModelConfig` outside this context is
+    deprecated in favor of ``scalable.yaml`` + manifest parsing.
+    """
+
+    global _MODELCONFIG_ADAPTER_CONTEXT
+    previous = _MODELCONFIG_ADAPTER_CONTEXT
+    _MODELCONFIG_ADAPTER_CONTEXT = True
+    try:
+        yield
+    finally:
+        _MODELCONFIG_ADAPTER_CONTEXT = previous
 
 async def get_cmd_comm(
     port: int, communicator_path: str | None = None
@@ -105,11 +129,22 @@ class ModelConfig:
             fresh data or older data such as previously set binded directories.
             Defaults to True so a new config_dict is made.
         """
+        if not _MODELCONFIG_ADAPTER_CONTEXT:
+            warnings.warn(
+                "ModelConfig Dockerfile discovery is deprecated and will be "
+                "replaced by scalable.yaml manifest parsing. Use "
+                "scalable.manifest.parser.parse_manifest(...) and provider "
+                "adapters instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
         # HARDCODING CURRENT DIRECTORY
         self.config_dict = {}
         cwd = os.getcwd()
         if path is None:
             self.path = os.path.abspath(os.path.join(cwd, "config_dict.yaml"))
+        else:
+            self.path = os.path.abspath(path)
         dockerfile_path = os.path.abspath(os.path.join(cwd, "Dockerfile"))
         list_avail_command = (
             r"sed -n 's/^FROM[[:space:]]\+[^ ]\+[[:space:]]\+AS[[:space:]]\+\([^ ]\+\)$/\\1/p' "

--- a/tests/integration/test_local_provider_end_to_end.py
+++ b/tests/integration/test_local_provider_end_to_end.py
@@ -1,0 +1,49 @@
+"""Integration test for LocalProvider (Phase 1 WU-5)."""
+
+from __future__ import annotations
+
+import pytest
+
+from scalable.manifest.parser import parse_manifest
+from scalable.providers.base import DeploymentSpec
+from scalable.providers.local import LocalProvider
+
+
+def _increment(value: int) -> int:
+    return value + 1
+
+
+@pytest.mark.integration
+def test_local_provider_end_to_end_submit_tagged_task() -> None:
+    manifest = {
+        "version": 1,
+        "project": {"name": "demo"},
+        "targets": {
+            "local": {
+                "provider": "local",
+                "max_workers": 1,
+                "threads_per_worker": 1,
+                "processes": False,
+                "containers": "none",
+            }
+        },
+        "components": {
+            "gcam": {"cpus": 1, "memory": "1G"},
+        },
+        "tasks": {
+            "run_gcam": {"component": "gcam"},
+        },
+    }
+
+    model = parse_manifest(manifest)
+    spec = DeploymentSpec.from_manifest(model, target_name="local")
+    provider = LocalProvider()
+    handle = provider.build_cluster(spec)
+    client = handle.client_factory()
+    try:
+        future = client.submit(_increment, 41, tag="gcam")
+        assert future.result(timeout=10) == 42
+    finally:
+        client.close()
+        provider.close(handle)
+

--- a/tests/unit/test_cli_plan.py
+++ b/tests/unit/test_cli_plan.py
@@ -1,0 +1,87 @@
+"""Unit tests for ``scalable plan`` CLI behavior."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from scalable.cli.main import main
+
+
+def _write_valid_manifest(path: Path) -> None:
+    path.write_text(
+        """
+version: 1
+project:
+  name: demo
+targets:
+  local:
+    provider: local
+    max_workers: 1
+components:
+  gcam:
+    cpus: 1
+    memory: 1G
+tasks:
+  run_gcam:
+    component: gcam
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+
+def test_cli_plan_dry_run_writes_plan_and_manifest_lock(tmp_path: Path, capsys) -> None:
+    manifest_path = tmp_path / "scalable.yaml"
+    _write_valid_manifest(manifest_path)
+    output_path = tmp_path / "plan.json"
+
+    code = main(
+        [
+            "plan",
+            str(manifest_path),
+            "--target",
+            "local",
+            "--dry-run",
+            "--output",
+            str(output_path),
+        ]
+    )
+
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    file_payload = json.loads(output_path.read_text(encoding="utf-8"))
+    lock_path = tmp_path / "manifest.lock"
+
+    assert code == 0
+    assert payload["target"] == "local"
+    assert file_payload == payload
+    assert lock_path.exists()
+    assert len(lock_path.read_text(encoding="utf-8").strip()) == 64
+
+
+def test_cli_plan_requires_dry_run_flag(tmp_path: Path, capsys) -> None:
+    manifest_path = tmp_path / "scalable.yaml"
+    _write_valid_manifest(manifest_path)
+    output_path = tmp_path / "plan.json"
+
+    code = main(["plan", str(manifest_path), "--output", str(output_path)])
+
+    captured = capsys.readouterr()
+    assert code == 2
+    assert "supports dry-run" in captured.err
+    assert not output_path.exists()
+
+
+def test_cli_plan_invalid_manifest_returns_nonzero(tmp_path: Path, capsys) -> None:
+    manifest_path = tmp_path / "scalable.yaml"
+    _write_valid_manifest(manifest_path)
+    text = manifest_path.read_text(encoding="utf-8")
+    text = text.replace("component: gcam", "component: missing_component")
+    manifest_path.write_text(text, encoding="utf-8")
+
+    code = main(["plan", str(manifest_path), "--dry-run"])
+
+    captured = capsys.readouterr()
+    assert code == 1
+    assert "planning failed" in captured.err
+

--- a/tests/unit/test_cli_validate.py
+++ b/tests/unit/test_cli_validate.py
@@ -1,0 +1,81 @@
+"""Unit tests for ``scalable validate`` CLI behavior."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from scalable.cli.main import main
+
+
+def _write_valid_manifest(path: Path) -> None:
+    path.write_text(
+        """
+version: 1
+project:
+  name: demo
+targets:
+  local:
+    provider: local
+    max_workers: 1
+components:
+  gcam:
+    cpus: 1
+    memory: 1G
+tasks:
+  run_gcam:
+    component: gcam
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+
+def test_cli_validate_valid_manifest_returns_zero(tmp_path: Path, capsys) -> None:
+    manifest_path = tmp_path / "scalable.yaml"
+    _write_valid_manifest(manifest_path)
+
+    code = main(["validate", str(manifest_path), "--target", "local"])
+
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    assert code == 0
+    assert payload["ok"] is True
+    assert payload["errors"] == []
+
+
+def test_cli_validate_invalid_manifest_returns_nonzero(tmp_path: Path, capsys) -> None:
+    manifest_path = tmp_path / "scalable.yaml"
+    _write_valid_manifest(manifest_path)
+    text = manifest_path.read_text(encoding="utf-8")
+    text = text.replace("component: gcam", "component: missing_component")
+    manifest_path.write_text(text, encoding="utf-8")
+
+    code = main(["validate", str(manifest_path), "--target", "local"])
+
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    assert code == 1
+    assert payload["ok"] is False
+    assert any(err["path"] == "tasks.run_gcam.component" for err in payload["errors"])
+
+
+def test_cli_validate_schema_error_returns_nonzero(tmp_path: Path, capsys) -> None:
+    manifest_path = tmp_path / "scalable.yaml"
+    manifest_path.write_text("version: 1\n", encoding="utf-8")
+
+    code = main(["validate", str(manifest_path)])
+
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    assert code == 1
+    assert payload["ok"] is False
+    assert payload["errors"][0]["code"] == "E_MANIFEST"
+
+
+def test_cli_stub_command_returns_pointer_message(capsys) -> None:
+    code = main(["diagnose"])
+
+    captured = capsys.readouterr()
+    assert code == 2
+    assert "planned for Phase 4" in captured.err
+

--- a/tests/unit/test_common_settings.py
+++ b/tests/unit/test_common_settings.py
@@ -23,11 +23,15 @@ def test_settings_defaults():
     s = common.Settings()
     assert s.cache_dir == "./cache"
     assert s.seed == common.DEFAULT_SEED
+    assert s.manifest_path == "./scalable.yaml"
+    assert s.target is None
 
 
 def test_settings_env_overrides(monkeypatch):
     monkeypatch.setenv("SCALABLE_CACHE_DIR", "/tmp/scalable-test-cache")
     monkeypatch.setenv("SCALABLE_SEED", "42")
+    monkeypatch.setenv("SCALABLE_MANIFEST", "/tmp/scalable.yaml")
+    monkeypatch.setenv("SCALABLE_TARGET", "local")
 
     # Reload to pick up env vars in field defaults.
     from scalable import common as common_mod
@@ -35,6 +39,8 @@ def test_settings_env_overrides(monkeypatch):
     s = common_mod.Settings()
     assert s.cache_dir == "/tmp/scalable-test-cache"
     assert s.seed == 42
+    assert s.manifest_path == "/tmp/scalable.yaml"
+    assert s.target == "local"
 
 
 def test_legacy_module_aliases_match_singleton():

--- a/tests/unit/test_manifest_adapter.py
+++ b/tests/unit/test_manifest_adapter.py
@@ -1,0 +1,127 @@
+"""Unit tests for :mod:`scalable.manifest.adapter` (Phase 1 WU-7)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from scalable.manifest.adapter import (
+    add_components_to_legacy_cluster,
+    build_slurm_cluster_kwargs,
+    create_legacy_slurm_cluster,
+)
+from scalable.manifest.parser import parse_manifest
+from scalable.providers.base import DeploymentSpec
+
+
+def _spec() -> DeploymentSpec:
+    model = parse_manifest(
+        {
+            "version": 1,
+            "project": {"name": "demo"},
+            "targets": {
+                "hpc": {
+                    "provider": "slurm",
+                    "queue": "short",
+                    "account": "GCIMS",
+                    "walltime": "02:00:00",
+                    "interface": "ib0",
+                    "comm_port": 50051,
+                    "logs_location": "/tmp/scalable-logs",
+                    "suppress_logs": False,
+                }
+            },
+            "components": {
+                "gcam": {
+                    "image": "/containers/gcam.sif",
+                    "cpus": 2,
+                    "memory": "8G",
+                    "mounts": {"/host/data": "/data"},
+                    "preload_script": "/tmp/preload.py",
+                },
+                "stitches": {
+                    "image": "/containers/stitches.sif",
+                    "cpus": 1,
+                    "memory": "4G",
+                    "mounts": {"/host/data": "/data"},
+                },
+            },
+            "tasks": {
+                "run_gcam": {"component": "gcam"},
+                "run_stitches": {"component": "stitches"},
+            },
+        }
+    )
+    return DeploymentSpec.from_manifest(model, target_name="hpc")
+
+
+def test_build_slurm_cluster_kwargs_translation() -> None:
+    kwargs = build_slurm_cluster_kwargs(_spec())
+
+    assert kwargs == {
+        "queue": "short",
+        "account": "GCIMS",
+        "walltime": "02:00:00",
+        "interface": "ib0",
+        "name": None,
+        "logs_location": "/tmp/scalable-logs",
+        "suppress_logs": False,
+        "comm_port": 50051,
+    }
+
+
+@dataclass
+class _FakeCluster:
+    add_container_calls: list[dict[str, Any]] = field(default_factory=list)
+
+    def add_container(self, **kwargs: Any) -> None:
+        self.add_container_calls.append(kwargs)
+
+
+def test_add_components_to_legacy_cluster_all_components() -> None:
+    spec = _spec()
+    cluster = _FakeCluster()
+
+    added = add_components_to_legacy_cluster(spec, cluster)
+
+    assert added == ["gcam", "stitches"]
+    assert len(cluster.add_container_calls) == 2
+    assert cluster.add_container_calls[0]["tag"] == "gcam"
+    assert cluster.add_container_calls[0]["dirs"] == {"/host/data": "/data"}
+    assert cluster.add_container_calls[0]["path"] == "/containers/gcam.sif"
+    assert cluster.add_container_calls[0]["cpus"] == 2
+    assert cluster.add_container_calls[0]["memory"] == "8G"
+    assert cluster.add_container_calls[0]["preload_script"] == "/tmp/preload.py"
+
+
+def test_add_components_to_legacy_cluster_subset() -> None:
+    spec = _spec()
+    cluster = _FakeCluster()
+
+    added = add_components_to_legacy_cluster(spec, cluster, components=["stitches"])
+
+    assert added == ["stitches"]
+    assert len(cluster.add_container_calls) == 1
+    assert cluster.add_container_calls[0]["tag"] == "stitches"
+
+
+@dataclass
+class _FactoryCapture:
+    kwargs: dict[str, Any]
+
+
+def test_create_legacy_slurm_cluster_uses_factory() -> None:
+    captured: list[_FactoryCapture] = []
+
+    def _factory(**kwargs: Any) -> _FactoryCapture:
+        obj = _FactoryCapture(kwargs=kwargs)
+        captured.append(obj)
+        return obj
+
+    result = create_legacy_slurm_cluster(_spec(), cluster_cls=_factory)
+
+    assert len(captured) == 1
+    assert result is captured[0]
+    assert captured[0].kwargs["queue"] == "short"
+    assert captured[0].kwargs["comm_port"] == 50051
+

--- a/tests/unit/test_manifest_parser.py
+++ b/tests/unit/test_manifest_parser.py
@@ -1,0 +1,321 @@
+"""Unit tests for :mod:`scalable.manifest.parser` (Phase 1 WU-2).
+
+This suite focuses on syntax/schema parsing and environment expansion only.
+Cross-field semantic checks (unknown component references, provider registry
+lookups, memory parseability, mount path policy) are covered in
+``test_manifest_validate.py`` under WU-3.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scalable.manifest.errors import ManifestParseError, ManifestSchemaError
+from scalable.manifest.parser import expand_env_vars, load_manifest, parse_manifest
+from scalable.manifest.schema import SCHEMA_VERSION
+
+
+def test_expand_env_vars_expands_recursive_tree() -> None:
+    env = {
+        "ROOT": "/data",
+        "IMAGE_TAG": "7.0",
+        "OMP": "6",
+    }
+    tree = {
+        "a": "${ROOT}/inputs",
+        "b": ["x", "${ROOT}/outputs", {"c": "ghcr.io/demo:${IMAGE_TAG}"}],
+        "d": {"OMP_NUM_THREADS": "${OMP}"},
+    }
+
+    out = expand_env_vars(tree, env=env)
+
+    assert out == {
+        "a": "/data/inputs",
+        "b": ["x", "/data/outputs", {"c": "ghcr.io/demo:7.0"}],
+        "d": {"OMP_NUM_THREADS": "6"},
+    }
+
+
+def test_expand_env_vars_supports_default_clause() -> None:
+    tree = {
+        "path": "${UNSET_VAR:-/tmp/default}",
+        "nested": ["${OTHER_UNSET:-fallback}"]
+    }
+    out = expand_env_vars(tree, env={})
+    assert out == {"path": "/tmp/default", "nested": ["fallback"]}
+
+
+def test_expand_env_vars_raises_when_unset_without_default() -> None:
+    with pytest.raises(ManifestParseError, match="not set"):
+        expand_env_vars({"path": "${MISSING}"}, env={})
+
+
+def test_parse_manifest_from_mapping_success() -> None:
+    manifest = {
+        "version": SCHEMA_VERSION,
+        "project": {"name": "ia-workflow", "local_cache": "./.scalable/cache"},
+        "targets": {
+            "local": {
+                "provider": "local",
+                "max_workers": 4,
+                "containers": "none",
+            }
+        },
+        "components": {
+            "gcam": {
+                "image": "ghcr.io/jgcri/scalable-gcam:7.0",
+                "runtime": "apptainer",
+                "cpus": 6,
+                "memory": "20G",
+                "mounts": {"/host/data": "/data"},
+                "env": {"OMP_NUM_THREADS": "6"},
+                "tags": ["iam", "climate"],
+            }
+        },
+        "tasks": {
+            "run_gcam": {
+                "component": "gcam",
+                "cache": True,
+                "outputs": {"database": "dir"},
+            }
+        },
+    }
+
+    model = parse_manifest(manifest)
+
+    assert model.version == SCHEMA_VERSION
+    assert model.project.name == "ia-workflow"
+    assert "local" in model.targets
+    assert model.targets["local"].provider == "local"
+    # target extras are provider passthrough and preserved
+    assert model.targets["local"].options["max_workers"] == 4
+    assert model.targets["local"].options["containers"] == "none"
+    assert model.components["gcam"].cpus == 6
+    assert model.tasks["run_gcam"].cache is True
+
+
+def test_parse_manifest_from_yaml_string_with_env_expansion() -> None:
+    yaml_text = """
+version: 1
+project:
+  name: integrated-assessment-workflow
+  default_storage: ${STORAGE_URI}
+targets:
+  hpc:
+    provider: slurm
+    queue: short
+    account: GCIMS
+components:
+  gcam:
+    image: ghcr.io/jgcri/scalable-gcam:${GCAM_TAG}
+    runtime: apptainer
+    cpus: 6
+    memory: 20G
+tasks:
+  run_gcam:
+    component: gcam
+    cache: true
+"""
+    env = {
+        "STORAGE_URI": "s3://my-bucket/scalable-runs/",
+        "GCAM_TAG": "7.0",
+    }
+
+    model = parse_manifest(yaml_text, env=env)
+
+    assert model.project.default_storage == "s3://my-bucket/scalable-runs/"
+    assert model.components["gcam"].image == "ghcr.io/jgcri/scalable-gcam:7.0"
+
+
+def test_load_manifest_from_file_sets_source_path(tmp_path: Path) -> None:
+    manifest_path = tmp_path / "scalable.yaml"
+    manifest_path.write_text(
+        """
+version: 1
+project:
+  name: demo
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+    model = load_manifest(manifest_path)
+
+    assert model.project.name == "demo"
+    assert model.source_path == str(manifest_path)
+
+
+def test_parse_manifest_rejects_empty_document() -> None:
+    with pytest.raises(ManifestSchemaError, match="empty"):
+        parse_manifest("")
+
+
+def test_parse_manifest_rejects_non_mapping_top_level() -> None:
+    with pytest.raises(ManifestSchemaError, match="top level"):
+        parse_manifest("- not\n- a\n- mapping\n")
+
+
+def test_parse_manifest_rejects_malformed_yaml() -> None:
+    with pytest.raises(ManifestParseError, match="malformed YAML"):
+        parse_manifest("version: [1\n")
+
+
+def test_parse_manifest_rejects_unknown_top_level_keys() -> None:
+    with pytest.raises(ManifestSchemaError, match="unknown top-level"):
+        parse_manifest(
+            {
+                "version": 1,
+                "project": {"name": "demo"},
+                "componentz": {},
+            }
+        )
+
+
+def test_parse_manifest_rejects_missing_required_top_level_keys() -> None:
+    with pytest.raises(ManifestSchemaError, match="missing required"):
+        parse_manifest({"version": 1})
+
+
+def test_parse_manifest_rejects_non_integer_version() -> None:
+    with pytest.raises(ManifestSchemaError, match="must be an integer"):
+        parse_manifest({"version": "1", "project": {"name": "demo"}})
+
+
+def test_parse_manifest_rejects_unsupported_version() -> None:
+    with pytest.raises(ManifestSchemaError, match="not supported"):
+        parse_manifest({"version": 999, "project": {"name": "demo"}})
+
+
+def test_parse_manifest_rejects_invalid_project_name() -> None:
+    with pytest.raises(ManifestSchemaError, match=r"project\.name"):
+        parse_manifest({"version": 1, "project": {"name": ""}})
+
+
+def test_parse_manifest_rejects_unknown_project_key() -> None:
+    with pytest.raises(ManifestSchemaError, match="unknown 'project'"):
+        parse_manifest(
+            {
+                "version": 1,
+                "project": {"name": "demo", "unknown": "x"},
+            }
+        )
+
+
+def test_parse_manifest_rejects_target_without_provider() -> None:
+    with pytest.raises(ManifestSchemaError, match=r"targets\.local\.provider"):
+        parse_manifest(
+            {
+                "version": 1,
+                "project": {"name": "demo"},
+                "targets": {"local": {}},
+            }
+        )
+
+
+def test_parse_manifest_rejects_unknown_component_key() -> None:
+    with pytest.raises(ManifestSchemaError, match=r"unknown 'components\.gcam'"):
+        parse_manifest(
+            {
+                "version": 1,
+                "project": {"name": "demo"},
+                "components": {
+                    "gcam": {
+                        "cpus": 1,
+                        "weird": True,
+                    }
+                },
+            }
+        )
+
+
+def test_parse_manifest_rejects_component_invalid_types() -> None:
+    with pytest.raises(ManifestSchemaError, match="cpus"):
+        parse_manifest(
+            {
+                "version": 1,
+                "project": {"name": "demo"},
+                "components": {"gcam": {"cpus": 0}},
+            }
+        )
+
+    with pytest.raises(ManifestSchemaError, match="memory"):
+        parse_manifest(
+            {
+                "version": 1,
+                "project": {"name": "demo"},
+                "components": {"gcam": {"memory": 32}},
+            }
+        )
+
+    with pytest.raises(ManifestSchemaError, match="mounts"):
+        parse_manifest(
+            {
+                "version": 1,
+                "project": {"name": "demo"},
+                "components": {"gcam": {"mounts": ["/a:/b"]}},
+            }
+        )
+
+    with pytest.raises(ManifestSchemaError, match="env"):
+        parse_manifest(
+            {
+                "version": 1,
+                "project": {"name": "demo"},
+                "components": {"gcam": {"env": ["OMP=6"]}},
+            }
+        )
+
+    with pytest.raises(ManifestSchemaError, match="tags"):
+        parse_manifest(
+            {
+                "version": 1,
+                "project": {"name": "demo"},
+                "components": {"gcam": {"tags": "climate"}},
+            }
+        )
+
+
+def test_parse_manifest_rejects_unknown_task_key() -> None:
+    with pytest.raises(ManifestSchemaError, match=r"unknown 'tasks\.run_gcam'"):
+        parse_manifest(
+            {
+                "version": 1,
+                "project": {"name": "demo"},
+                "tasks": {
+                    "run_gcam": {
+                        "component": "gcam",
+                        "unexpected": "x",
+                    }
+                },
+            }
+        )
+
+
+def test_parse_manifest_rejects_task_invalid_types() -> None:
+    with pytest.raises(ManifestSchemaError, match="component"):
+        parse_manifest(
+            {
+                "version": 1,
+                "project": {"name": "demo"},
+                "tasks": {"run_gcam": {"component": 5}},
+            }
+        )
+
+    with pytest.raises(ManifestSchemaError, match="cache"):
+        parse_manifest(
+            {
+                "version": 1,
+                "project": {"name": "demo"},
+                "tasks": {"run_gcam": {"component": "gcam", "cache": "yes"}},
+            }
+        )
+
+    with pytest.raises(ManifestSchemaError, match="outputs"):
+        parse_manifest(
+            {
+                "version": 1,
+                "project": {"name": "demo"},
+                "tasks": {"run_gcam": {"component": "gcam", "outputs": ["dir"]}},
+            }
+        )

--- a/tests/unit/test_manifest_validate.py
+++ b/tests/unit/test_manifest_validate.py
@@ -1,0 +1,189 @@
+"""Unit tests for :mod:`scalable.manifest.validate` (Phase 1 WU-3)."""
+
+from __future__ import annotations
+
+from scalable.manifest.parser import parse_manifest
+from scalable.manifest.validate import validate_manifest
+
+
+def _base_manifest() -> dict:
+    return {
+        "version": 1,
+        "project": {"name": "demo"},
+        "targets": {
+            "local": {
+                "provider": "local",
+                "max_workers": 4,
+            }
+        },
+        "components": {
+            "gcam": {
+                "cpus": 2,
+                "memory": "8G",
+                "mounts": {
+                    "/host/data": "/data",
+                },
+            }
+        },
+        "tasks": {
+            "run_gcam": {
+                "component": "gcam",
+                "cache": True,
+            }
+        },
+    }
+
+
+def test_validate_manifest_ok_for_valid_manifest() -> None:
+    model = parse_manifest(_base_manifest())
+
+    report = validate_manifest(model)
+
+    assert report.ok is True
+    assert report.errors == []
+    assert report.warnings == []
+
+
+def test_validate_manifest_warns_when_no_targets_or_tasks() -> None:
+    manifest = {
+        "version": 1,
+        "project": {"name": "demo"},
+        "targets": {},
+        "components": {},
+        "tasks": {},
+    }
+    model = parse_manifest(manifest)
+
+    report = validate_manifest(model)
+
+    assert report.ok is True
+    assert len(report.warnings) == 2
+    warning_paths = {w.path for w in report.warnings}
+    assert "targets" in warning_paths
+    assert "tasks" in warning_paths
+
+
+def test_validate_manifest_errors_for_unknown_provider() -> None:
+    manifest = _base_manifest()
+    manifest["targets"]["local"]["provider"] = "kubernetes"
+    model = parse_manifest(manifest)
+
+    report = validate_manifest(model, known_providers={"local", "slurm"})
+
+    assert report.ok is False
+    assert len(report.errors) == 1
+    issue = report.errors[0]
+    assert issue.path == "targets.local.provider"
+    assert issue.code == "E_UNKNOWN_PROVIDER"
+    assert "unknown provider" in issue.message
+
+
+def test_validate_manifest_accepts_custom_known_provider_set() -> None:
+    manifest = _base_manifest()
+    manifest["targets"]["local"]["provider"] = "kubernetes"
+    model = parse_manifest(manifest)
+
+    report = validate_manifest(model, known_providers={"local", "slurm", "kubernetes"})
+
+    assert report.ok is True
+    assert report.errors == []
+
+
+def test_validate_manifest_errors_for_unknown_task_component() -> None:
+    manifest = _base_manifest()
+    manifest["tasks"]["run_gcam"]["component"] = "missing_component"
+    model = parse_manifest(manifest)
+
+    report = validate_manifest(model)
+
+    assert report.ok is False
+    assert len(report.errors) == 1
+    issue = report.errors[0]
+    assert issue.path == "tasks.run_gcam.component"
+    assert issue.code == "E_UNKNOWN_COMPONENT"
+    assert "unknown component" in issue.message
+
+
+def test_validate_manifest_errors_for_unparseable_memory() -> None:
+    manifest = _base_manifest()
+    manifest["components"]["gcam"]["memory"] = "not-a-memory"
+    model = parse_manifest(manifest)
+
+    report = validate_manifest(model)
+
+    assert report.ok is False
+    assert len(report.errors) == 1
+    issue = report.errors[0]
+    assert issue.path == "components.gcam.memory"
+    assert issue.code == "E_BAD_MEMORY"
+    assert "not parseable" in issue.message
+
+
+def test_validate_manifest_errors_for_nonpositive_memory() -> None:
+    manifest = _base_manifest()
+    manifest["components"]["gcam"]["memory"] = "0B"
+    model = parse_manifest(manifest)
+
+    report = validate_manifest(model)
+
+    assert report.ok is False
+    assert len(report.errors) == 1
+    issue = report.errors[0]
+    assert issue.path == "components.gcam.memory"
+    assert issue.code == "E_NONPOSITIVE_MEMORY"
+    assert "greater than zero" in issue.message
+
+
+def test_validate_manifest_errors_for_relative_host_mount_path() -> None:
+    manifest = _base_manifest()
+    manifest["components"]["gcam"]["mounts"] = {
+        "relative/host/path": "/data",
+    }
+    model = parse_manifest(manifest)
+
+    report = validate_manifest(model)
+
+    assert report.ok is False
+    assert len(report.errors) == 1
+    issue = report.errors[0]
+    assert issue.path == "components.gcam.mounts['relative/host/path']"
+    assert issue.code == "E_RELATIVE_HOST_MOUNT"
+
+
+def test_validate_manifest_errors_for_relative_container_mount_path() -> None:
+    manifest = _base_manifest()
+    manifest["components"]["gcam"]["mounts"] = {
+        "/host/data": "relative/container/path",
+    }
+    model = parse_manifest(manifest)
+
+    report = validate_manifest(model)
+
+    assert report.ok is False
+    assert len(report.errors) == 1
+    issue = report.errors[0]
+    assert issue.path == "components.gcam.mounts['/host/data']"
+    assert issue.code == "E_RELATIVE_CONTAINER_MOUNT"
+
+
+def test_validate_manifest_collects_multiple_errors() -> None:
+    manifest = _base_manifest()
+    manifest["targets"]["local"]["provider"] = "mystery"
+    manifest["components"]["gcam"]["memory"] = "bad"
+    manifest["components"]["gcam"]["mounts"] = {
+        "relative_host": "relative_container",
+    }
+    manifest["tasks"]["run_gcam"]["component"] = "missing"
+    model = parse_manifest(manifest)
+
+    report = validate_manifest(model)
+
+    assert report.ok is False
+    assert len(report.errors) == 5
+    codes = {issue.code for issue in report.errors}
+    assert "E_UNKNOWN_PROVIDER" in codes
+    assert "E_BAD_MEMORY" in codes
+    assert "E_RELATIVE_HOST_MOUNT" in codes
+    assert "E_RELATIVE_CONTAINER_MOUNT" in codes
+    assert "E_UNKNOWN_COMPONENT" in codes
+

--- a/tests/unit/test_modelconfig_deprecation.py
+++ b/tests/unit/test_modelconfig_deprecation.py
@@ -1,0 +1,46 @@
+"""Tests for ModelConfig deprecation behavior (Phase 1 WU-7)."""
+
+from __future__ import annotations
+
+import warnings
+from pathlib import Path
+
+from scalable.utilities import ModelConfig, model_config_adapter_context
+
+
+def _write_minimal_dockerfile(path: Path) -> None:
+    path.write_text(
+        """
+FROM ubuntu:22.04 AS gcam
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+
+def test_modelconfig_direct_init_emits_deprecation(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.chdir(tmp_path)
+    _write_minimal_dockerfile(tmp_path / "Dockerfile")
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always", DeprecationWarning)
+        ModelConfig(path=str(tmp_path / "config_dict.yaml"), path_overwrite=True)
+
+    deprecations = [w for w in caught if issubclass(w.category, DeprecationWarning)]
+    assert len(deprecations) >= 1
+    assert "ModelConfig Dockerfile discovery is deprecated" in str(deprecations[0].message)
+
+
+def test_modelconfig_inside_adapter_context_suppresses_deprecation(
+    monkeypatch, tmp_path: Path
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    _write_minimal_dockerfile(tmp_path / "Dockerfile")
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always", DeprecationWarning)
+        with model_config_adapter_context():
+            config = ModelConfig(path=str(tmp_path / "config_dict.yaml"), path_overwrite=True)
+
+    assert isinstance(config, ModelConfig)
+    deprecations = [w for w in caught if issubclass(w.category, DeprecationWarning)]
+    assert deprecations == []

--- a/tests/unit/test_planning_dryrun.py
+++ b/tests/unit/test_planning_dryrun.py
@@ -1,0 +1,75 @@
+"""Tests for deterministic dry-run planning (WU-9 foundations)."""
+
+from __future__ import annotations
+
+from scalable.manifest.parser import parse_manifest
+from scalable.planning.dryrun import build_dry_run_plan, compute_manifest_lock
+from scalable.providers.base import DeploymentSpec
+
+
+def _spec() -> DeploymentSpec:
+    model = parse_manifest(
+        {
+            "version": 1,
+            "project": {"name": "demo"},
+            "targets": {
+                "hpc": {
+                    "provider": "slurm",
+                    "walltime": "02:00:00",
+                    "comm_port": 50051,
+                }
+            },
+            "components": {
+                "gcam": {"cpus": 2, "memory": "8G"},
+                "stitches": {"cpus": 1, "memory": "4G"},
+            },
+            "tasks": {
+                "run_gcam": {"component": "gcam"},
+                "run_stitches": {"component": "stitches"},
+            },
+        }
+    )
+    return DeploymentSpec.from_manifest(model, target_name="hpc")
+
+
+def test_compute_manifest_lock_deterministic() -> None:
+    payload_a = {"b": 2, "a": 1, "nested": {"x": [3, 2, 1]}}
+    payload_b = {"nested": {"x": [3, 2, 1]}, "a": 1, "b": 2}
+
+    lock_a = compute_manifest_lock(payload_a)
+    lock_b = compute_manifest_lock(payload_b)
+
+    assert lock_a == lock_b
+    assert len(lock_a) == 64
+
+
+def test_build_dry_run_plan_maps_tasks_and_resources() -> None:
+    plan = build_dry_run_plan(_spec())
+
+    assert plan.target_name == "hpc"
+    assert plan.provider_name == "slurm"
+    assert len(plan.manifest_lock) == 64
+    assert plan.task_to_component == {
+        "run_gcam": "gcam",
+        "run_stitches": "stitches",
+    }
+
+    assert plan.scale_plan.workers_by_tag == {"gcam": 1, "stitches": 1}
+    assert plan.scale_plan.resources_by_tag["gcam"].cpus == 2
+    assert plan.scale_plan.resources_by_tag["gcam"].memory == "8G"
+    assert plan.scale_plan.resources_by_tag["gcam"].walltime == "02:00:00"
+    assert plan.scale_plan.resources_by_tag["stitches"].cpus == 1
+
+
+def test_dry_run_plan_to_dict_shape() -> None:
+    plan = build_dry_run_plan(_spec())
+    payload = plan.to_dict()
+
+    assert payload["version"] == 1
+    assert payload["target"] == "hpc"
+    assert payload["provider"] == "slurm"
+    assert payload["manifest_lock"] == plan.manifest_lock
+    assert payload["task_to_component"]["run_gcam"] == "gcam"
+    assert payload["scale_plan"]["workers_by_tag"]["gcam"] == 1
+    assert payload["scale_plan"]["resources_by_tag"]["gcam"]["cpus"] == 2
+

--- a/tests/unit/test_providers_base_registry.py
+++ b/tests/unit/test_providers_base_registry.py
@@ -168,3 +168,9 @@ def test_iter_provider_names_from_runtime_registry() -> None:
 
     assert names == {"dummy"}
 
+
+def test_get_provider_loads_builtin_local_provider_lazily() -> None:
+    provider = get_provider("local")
+
+    assert provider.name == "local"
+    assert "local" in iter_provider_names(include_entrypoints=False)

--- a/tests/unit/test_providers_base_registry.py
+++ b/tests/unit/test_providers_base_registry.py
@@ -1,0 +1,170 @@
+"""Unit tests for provider base types and registry (Phase 1 WU-4)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+
+from scalable.manifest.parser import parse_manifest
+from scalable.providers.base import (
+    ClusterHandle,
+    DeploymentSpec,
+    ResourceRequest,
+    ScalePlan,
+)
+from scalable.providers.registry import (
+    clear_registry,
+    get_provider,
+    iter_provider_names,
+    register_provider,
+    register_providers,
+)
+
+
+@dataclass
+class DummyProvider:
+    name: str = "dummy"
+
+    def validate(self, spec):  # pragma: no cover - not needed in this suite
+        raise NotImplementedError
+
+    def build_cluster(self, spec):  # pragma: no cover - not needed in this suite
+        raise NotImplementedError
+
+    def scale(self, cluster, plan):  # pragma: no cover - not needed in this suite
+        raise NotImplementedError
+
+    def close(self, cluster):  # pragma: no cover - not needed in this suite
+        raise NotImplementedError
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry():
+    clear_registry()
+    yield
+    clear_registry()
+
+
+def test_deployment_spec_from_manifest() -> None:
+    model = parse_manifest(
+        {
+            "version": 1,
+            "project": {"name": "demo"},
+            "targets": {"local": {"provider": "local", "max_workers": 2}},
+            "components": {"gcam": {"cpus": 2, "memory": "8G"}},
+            "tasks": {"run_gcam": {"component": "gcam"}},
+        }
+    )
+
+    spec = DeploymentSpec.from_manifest(model, target_name="local")
+
+    assert spec.target_name == "local"
+    assert spec.provider_name == "local"
+    assert spec.target.options["max_workers"] == 2
+    assert "gcam" in spec.components
+    assert "run_gcam" in spec.tasks
+    assert spec.raw_manifest["version"] == 1
+
+
+def test_deployment_spec_from_manifest_missing_target_raises_keyerror() -> None:
+    model = parse_manifest({"version": 1, "project": {"name": "demo"}, "targets": {}})
+
+    with pytest.raises(KeyError):
+        DeploymentSpec.from_manifest(model, target_name="missing")
+
+
+def test_scale_plan_and_resource_request_defaults() -> None:
+    rr = ResourceRequest()
+    assert rr.cpus == 1
+    assert rr.memory is None
+    assert rr.walltime is None
+    assert rr.gpus is None
+
+    plan = ScalePlan()
+    assert plan.workers_by_tag == {}
+    assert plan.resources_by_tag == {}
+
+
+def test_cluster_handle_stores_backend_and_factory() -> None:
+    marker = object()
+
+    def _factory():
+        return marker
+
+    handle = ClusterHandle(backend="backend", client_factory=_factory, metadata={"k": "v"})
+
+    assert handle.backend == "backend"
+    assert handle.client_factory() is marker
+    assert handle.metadata == {"k": "v"}
+
+
+def test_register_provider_and_get_provider_from_class() -> None:
+    register_provider("dummy", DummyProvider)
+
+    provider = get_provider("dummy")
+
+    assert isinstance(provider, DummyProvider)
+    assert provider.name == "dummy"
+
+
+def test_register_provider_and_get_provider_from_callable_factory() -> None:
+    def factory():
+        return DummyProvider(name="dummy-factory")
+
+    register_provider("dummy", factory)
+
+    provider = get_provider("dummy")
+
+    assert isinstance(provider, DummyProvider)
+    assert provider.name == "dummy-factory"
+
+
+def test_register_provider_normalizes_name_and_lookup() -> None:
+    register_provider("  DuMmY  ", DummyProvider)
+
+    provider = get_provider("dummy")
+
+    assert isinstance(provider, DummyProvider)
+
+
+def test_register_provider_rejects_empty_name() -> None:
+    with pytest.raises(ValueError, match="non-empty"):
+        register_provider("   ", DummyProvider)
+
+
+def test_register_provider_rejects_duplicates() -> None:
+    register_provider("dummy", DummyProvider)
+
+    with pytest.raises(ValueError, match="already registered"):
+        register_provider("dummy", DummyProvider)
+
+
+def test_register_providers_bulk() -> None:
+    register_providers(
+        [
+            ("dummy1", DummyProvider),
+            ("dummy2", lambda: DummyProvider(name="dummy2")),
+        ]
+    )
+
+    p1 = get_provider("dummy1")
+    p2 = get_provider("dummy2")
+
+    assert isinstance(p1, DummyProvider)
+    assert isinstance(p2, DummyProvider)
+    assert p2.name == "dummy2"
+
+
+def test_get_provider_unknown_raises_keyerror() -> None:
+    with pytest.raises(KeyError, match="unknown provider"):
+        get_provider("missing")
+
+
+def test_iter_provider_names_from_runtime_registry() -> None:
+    register_provider("dummy", DummyProvider)
+
+    names = iter_provider_names(include_entrypoints=False)
+
+    assert names == {"dummy"}
+

--- a/tests/unit/test_providers_local.py
+++ b/tests/unit/test_providers_local.py
@@ -1,0 +1,131 @@
+"""Unit tests for :mod:`scalable.providers.local` (Phase 1 WU-5)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from scalable.manifest.parser import parse_manifest
+from scalable.providers.base import ClusterHandle, DeploymentSpec, ScalePlan
+from scalable.providers.local import LocalProvider
+
+
+def _manifest_dict() -> dict:
+    return {
+        "version": 1,
+        "project": {"name": "demo"},
+        "targets": {
+            "local": {
+                "provider": "local",
+                "max_workers": 2,
+                "threads_per_worker": 1,
+                "processes": False,
+                "containers": "none",
+            }
+        },
+        "components": {
+            "gcam": {"cpus": 2, "memory": "8G"},
+            "stitches": {"cpus": 1, "memory": "4G"},
+        },
+        "tasks": {
+            "run_gcam": {"component": "gcam"},
+            "run_stitches": {"component": "stitches"},
+        },
+    }
+
+
+def _spec() -> DeploymentSpec:
+    model = parse_manifest(_manifest_dict())
+    return DeploymentSpec.from_manifest(model, target_name="local")
+
+
+def test_validate_local_provider_ok() -> None:
+    provider = LocalProvider()
+
+    report = provider.validate(_spec())
+
+    assert report.ok is True
+    assert report.errors == []
+
+
+def test_validate_local_provider_rejects_bad_options() -> None:
+    manifest = _manifest_dict()
+    manifest["targets"]["local"]["max_workers"] = 0
+    manifest["targets"]["local"]["threads_per_worker"] = 0
+    manifest["targets"]["local"]["processes"] = "no"
+    manifest["targets"]["local"]["containers"] = "podman"
+    model = parse_manifest(manifest)
+    spec = DeploymentSpec.from_manifest(model, target_name="local")
+    provider = LocalProvider()
+
+    report = provider.validate(spec)
+
+    assert report.ok is False
+    codes = {issue.code for issue in report.errors}
+    assert "E_BAD_MAX_WORKERS" in codes
+    assert "E_BAD_THREADS_PER_WORKER" in codes
+    assert "E_BAD_PROCESSES_FLAG" in codes
+    assert "E_BAD_CONTAINERS_MODE" in codes
+
+
+def test_validate_local_provider_warns_for_deferred_containers() -> None:
+    manifest = _manifest_dict()
+    manifest["targets"]["local"]["containers"] = "docker"
+    model = parse_manifest(manifest)
+    spec = DeploymentSpec.from_manifest(model, target_name="local")
+    provider = LocalProvider()
+
+    report = provider.validate(spec)
+
+    assert report.ok is True
+    assert any(issue.code == "W_LOCAL_CONTAINERS_DEFERRED" for issue in report.warnings)
+
+
+def test_build_cluster_returns_handle_and_metadata() -> None:
+    provider = LocalProvider()
+    handle = provider.build_cluster(_spec())
+    try:
+        assert isinstance(handle, ClusterHandle)
+        assert handle.metadata["provider"] == "local"
+        assert handle.metadata["target"] == "local"
+        assert handle.metadata["n_workers"] == 2
+        assert handle.metadata["worker_resources"] == {"gcam": 1, "stitches": 1}
+    finally:
+        provider.close(handle)
+
+
+@dataclass
+class _ScaleRecorder:
+    value: int | None = None
+
+    def scale(self, target: int) -> None:
+        self.value = target
+
+
+def test_scale_sums_workers_by_tag() -> None:
+    provider = LocalProvider()
+    backend = _ScaleRecorder()
+    handle = ClusterHandle(backend=backend, client_factory=lambda: None)
+    plan = ScalePlan(workers_by_tag={"gcam": 2, "stitches": 1})
+
+    provider.scale(handle, plan)
+
+    assert backend.value == 3
+
+
+@dataclass
+class _CloseRecorder:
+    closed: bool = False
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def test_close_calls_backend_close() -> None:
+    provider = LocalProvider()
+    backend = _CloseRecorder()
+    handle = ClusterHandle(backend=backend, client_factory=lambda: None)
+
+    provider.close(handle)
+
+    assert backend.closed is True
+

--- a/tests/unit/test_providers_slurm.py
+++ b/tests/unit/test_providers_slurm.py
@@ -1,0 +1,170 @@
+"""Unit tests for :mod:`scalable.providers.slurm` (Phase 1 WU-6)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+import pytest
+
+from scalable.manifest.parser import parse_manifest
+from scalable.providers.base import ClusterHandle, DeploymentSpec, ScalePlan
+from scalable.providers.slurm import SlurmProvider
+
+
+def _manifest_dict() -> dict:
+    return {
+        "version": 1,
+        "project": {"name": "demo"},
+        "targets": {
+            "hpc": {
+                "provider": "slurm",
+                "queue": "short",
+                "account": "GCIMS",
+                "walltime": "02:00:00",
+                "interface": "ib0",
+                "comm_port": 50051,
+                "logs_location": "/tmp/scalable-logs",
+                "suppress_logs": False,
+            }
+        },
+        "components": {
+            "gcam": {
+                "image": "/containers/gcam.sif",
+                "cpus": 2,
+                "memory": "8G",
+                "mounts": {
+                    "/host/data": "/data",
+                },
+                "preload_script": "/tmp/preload.py",
+            }
+        },
+        "tasks": {
+            "run_gcam": {"component": "gcam"},
+        },
+    }
+
+
+def _spec() -> DeploymentSpec:
+    model = parse_manifest(_manifest_dict())
+    return DeploymentSpec.from_manifest(model, target_name="hpc")
+
+
+def test_validate_slurm_provider_ok() -> None:
+    provider = SlurmProvider()
+
+    report = provider.validate(_spec())
+
+    assert report.ok is True
+    assert report.errors == []
+
+
+def test_validate_slurm_provider_comm_port_required_when_env_missing(monkeypatch) -> None:
+    monkeypatch.delenv("COMM_PORT", raising=False)
+    manifest = _manifest_dict()
+    manifest["targets"]["hpc"].pop("comm_port")
+    spec = DeploymentSpec.from_manifest(parse_manifest(manifest), target_name="hpc")
+    provider = SlurmProvider()
+
+    report = provider.validate(spec)
+
+    assert report.ok is False
+    assert any(issue.code == "E_MISSING_COMM_PORT" for issue in report.errors)
+
+
+def test_validate_slurm_provider_rejects_bad_option_types() -> None:
+    manifest = _manifest_dict()
+    manifest["targets"]["hpc"]["walltime"] = "2h"
+    manifest["targets"]["hpc"]["comm_port"] = -1
+    manifest["targets"]["hpc"]["suppress_logs"] = "no"
+    manifest["targets"]["hpc"]["container_runtime"] = "podman"
+    spec = DeploymentSpec.from_manifest(parse_manifest(manifest), target_name="hpc")
+    provider = SlurmProvider()
+
+    report = provider.validate(spec)
+
+    assert report.ok is False
+    codes = {issue.code for issue in report.errors}
+    assert "E_BAD_WALLTIME" in codes
+    assert "E_BAD_COMM_PORT" in codes
+    assert "E_BAD_SUPPRESS_LOGS" in codes
+    assert "E_BAD_CONTAINER_RUNTIME" in codes
+
+
+@dataclass
+class _FakeSlurmCluster:
+    kwargs: dict[str, Any]
+    add_container_calls: list[dict[str, Any]] = field(default_factory=list)
+    add_workers_calls: list[dict[str, Any]] = field(default_factory=list)
+    closed: bool = False
+
+    def add_container(self, **kwargs: Any) -> None:
+        self.add_container_calls.append(kwargs)
+
+    def add_workers(self, **kwargs: Any) -> None:
+        self.add_workers_calls.append(kwargs)
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def test_build_cluster_translates_manifest_to_slurm_calls(monkeypatch) -> None:
+    created: list[_FakeSlurmCluster] = []
+
+    def _factory(**kwargs: Any) -> _FakeSlurmCluster:
+        instance = _FakeSlurmCluster(kwargs=kwargs)
+        created.append(instance)
+        return instance
+
+    monkeypatch.setattr("scalable.providers.slurm.SlurmCluster", _factory)
+
+    provider = SlurmProvider()
+    handle = provider.build_cluster(_spec())
+
+    assert isinstance(handle, ClusterHandle)
+    assert len(created) == 1
+    cluster = created[0]
+    assert cluster.kwargs["queue"] == "short"
+    assert cluster.kwargs["account"] == "GCIMS"
+    assert cluster.kwargs["walltime"] == "02:00:00"
+    assert cluster.kwargs["interface"] == "ib0"
+    assert cluster.kwargs["comm_port"] == 50051
+    assert cluster.kwargs["logs_location"] == "/tmp/scalable-logs"
+    assert cluster.kwargs["suppress_logs"] is False
+
+    assert len(cluster.add_container_calls) == 1
+    call = cluster.add_container_calls[0]
+    assert call["tag"] == "gcam"
+    assert call["dirs"] == {"/host/data": "/data"}
+    assert call["path"] == "/containers/gcam.sif"
+    assert call["cpus"] == 2
+    assert call["memory"] == "8G"
+    assert call["preload_script"] == "/tmp/preload.py"
+
+    assert handle.metadata["provider"] == "slurm"
+    assert handle.metadata["target"] == "hpc"
+
+
+def test_scale_calls_add_workers_per_tag() -> None:
+    provider = SlurmProvider()
+    backend = _FakeSlurmCluster(kwargs={})
+    handle = ClusterHandle(backend=backend, client_factory=lambda: None)
+    plan = ScalePlan(workers_by_tag={"gcam": 2, "stitches": 1, "noop": 0})
+
+    provider.scale(handle, plan)
+
+    assert backend.add_workers_calls == [
+        {"tag": "gcam", "n": 2},
+        {"tag": "stitches", "n": 1},
+    ]
+
+
+def test_close_calls_cluster_close() -> None:
+    provider = SlurmProvider()
+    backend = _FakeSlurmCluster(kwargs={})
+    handle = ClusterHandle(backend=backend, client_factory=lambda: None)
+
+    provider.close(handle)
+
+    assert backend.closed is True
+

--- a/tests/unit/test_public_api_exports.py
+++ b/tests/unit/test_public_api_exports.py
@@ -1,0 +1,27 @@
+"""Regression tests for top-level ``scalable`` public API exports."""
+
+from __future__ import annotations
+
+
+def test_top_level_exports_include_session_and_provider_symbols() -> None:
+    import scalable
+
+    exported = set(scalable.__all__)
+
+    assert "ScalableSession" in exported
+    assert "DeploymentProvider" in exported
+    assert "LocalProvider" in exported
+    assert "SlurmProvider" in exported
+
+
+def test_legacy_exports_remain_available() -> None:
+    import scalable
+
+    exported = set(scalable.__all__)
+
+    assert "JobQueueCluster" in exported
+    assert "SlurmCluster" in exported
+    assert "ScalableClient" in exported
+    assert "SEED" in exported
+    assert "settings" in exported
+

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -1,0 +1,142 @@
+"""Unit tests for :class:`scalable.session.session.ScalableSession`."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scalable.session.session import ScalableSession
+
+
+def _write_manifest(path: Path) -> None:
+    path.write_text(
+        """
+version: 1
+project:
+  name: demo
+targets:
+  local:
+    provider: local
+    max_workers: 1
+    threads_per_worker: 1
+    processes: false
+    containers: none
+  hpc:
+    provider: slurm
+    comm_port: 50051
+components:
+  gcam:
+    cpus: 1
+    memory: 1G
+tasks:
+  run_gcam:
+    component: gcam
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+
+def _identity(x: int) -> int:
+    return x
+
+
+def test_from_yaml_explicit_target(tmp_path: Path) -> None:
+    manifest_path = tmp_path / "scalable.yaml"
+    _write_manifest(manifest_path)
+
+    session = ScalableSession.from_yaml(manifest_path, target="local")
+
+    assert session.target_name == "local"
+    assert session.spec.provider_name == "local"
+
+
+def test_from_yaml_auto_prefers_local_when_not_in_slurm(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.delenv("SLURM_JOB_ID", raising=False)
+    monkeypatch.delenv("SLURM_CLUSTER_NAME", raising=False)
+    manifest_path = tmp_path / "scalable.yaml"
+    _write_manifest(manifest_path)
+
+    session = ScalableSession.from_yaml(manifest_path, target="auto")
+
+    assert session.target_name == "local"
+
+
+def test_from_yaml_auto_prefers_slurm_when_in_slurm_env(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("SLURM_JOB_ID", "12345")
+    manifest_path = tmp_path / "scalable.yaml"
+    _write_manifest(manifest_path)
+
+    session = ScalableSession.from_yaml(manifest_path, target="auto")
+
+    assert session.target_name == "hpc"
+
+
+def test_validate_ok_for_local_manifest(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.delenv("SLURM_JOB_ID", raising=False)
+    monkeypatch.delenv("SLURM_CLUSTER_NAME", raising=False)
+    manifest_path = tmp_path / "scalable.yaml"
+    _write_manifest(manifest_path)
+    session = ScalableSession.from_yaml(manifest_path, target="local")
+
+    report = session.validate()
+
+    assert report.ok is True
+
+
+def test_plan_raises_not_implemented_for_objective_policy(tmp_path: Path) -> None:
+    manifest_path = tmp_path / "scalable.yaml"
+    _write_manifest(manifest_path)
+    session = ScalableSession.from_yaml(manifest_path, target="local")
+
+    with pytest.raises(NotImplementedError):
+        session.plan(objective="minimize cost")
+
+    with pytest.raises(NotImplementedError):
+        session.plan(policy="safe")
+
+
+def test_plan_returns_dry_run_plan(tmp_path: Path) -> None:
+    manifest_path = tmp_path / "scalable.yaml"
+    _write_manifest(manifest_path)
+    session = ScalableSession.from_yaml(manifest_path, target="local")
+
+    plan = session.plan(dry_run=True)
+
+    assert plan.target_name == "local"
+    assert plan.provider_name == "local"
+    assert plan.scale_plan.workers_by_tag == {"gcam": 1}
+
+
+def test_start_and_close_local_session(tmp_path: Path) -> None:
+    manifest_path = tmp_path / "scalable.yaml"
+    _write_manifest(manifest_path)
+    session = ScalableSession.from_yaml(manifest_path, target="local")
+
+    client = session.start()
+    future = client.submit(_identity, 7, tag="gcam")
+    assert future.result(timeout=10) == 7
+
+    session.close()
+
+
+def test_start_with_target_mismatch_plan_raises(tmp_path: Path) -> None:
+    manifest_path = tmp_path / "scalable.yaml"
+    _write_manifest(manifest_path)
+    session_local = ScalableSession.from_yaml(manifest_path, target="local")
+    session_hpc = ScalableSession.from_yaml(manifest_path, target="hpc")
+    hpc_plan = session_hpc.plan(dry_run=True)
+
+    with pytest.raises(ValueError, match="does not match session target"):
+        session_local.start(hpc_plan)
+
+
+def test_context_manager_starts_and_closes(tmp_path: Path) -> None:
+    manifest_path = tmp_path / "scalable.yaml"
+    _write_manifest(manifest_path)
+    session = ScalableSession.from_yaml(manifest_path, target="local")
+
+    with session as client:
+        result = client.submit(_identity, 11, tag="gcam").result(timeout=10)
+        assert result == 11
+


### PR DESCRIPTION
# Phase 1: Provider Abstraction + `scalable.yaml` Manifest Foundation

## Summary

This PR delivers Phase 1 of the v2.0.0 roadmap defined in [`plans/v2.0.0_phase1_plan.md`](plans/v2.0.0_phase1_plan.md:1): a provider-neutral execution seam, a declarative manifest layer, a deterministic dry-run planner, the public `ScalableSession` API, and the `scalable validate` / `scalable plan --dry-run` CLI commands. All legacy v1.1.0 imperative APIs (`SlurmCluster`, `add_container`, `add_workers`, `ScalableClient`) remain functional. Phase 1 is strictly additive plus one targeted deprecation warning.

---

## Scope (delivered work units)

| WU | Description | Status |
|----|-------------|--------|
| WU-1 | Branch + package scaffolding + `pyproject.toml` bump to `2.0.0a1`, console script registration, optional extras placeholders | ✅ |
| WU-2 | Manifest schema dataclasses + YAML parser with `${VAR}` / `${VAR:-default}` expansion + version check | ✅ |
| WU-3 | Manifest semantic validator with `ValidationReport` / `ValidationIssue` | ✅ |
| WU-4 | `DeploymentProvider` protocol, `DeploymentSpec`, `ScalePlan`, `ResourceRequest`, `ClusterHandle`, registry with entry-point discovery | ✅ |
| WU-5 | `LocalProvider` over Dask `LocalCluster` + unit + integration coverage | ✅ |
| WU-6 | `SlurmProvider` translation layer over existing `SlurmCluster` + mocked unit tests | ✅ |
| WU-7 | Manifest-to-legacy adapter + `ModelConfig` deprecation warning gated by adapter context | ✅ |
| WU-8 | [`ScalableSession`](scalable/session/session.py:22) lifecycle API (`from_yaml`, `validate`, `plan`, `start`, `close`, context manager, reserved Phase 4 kwargs) | ✅ |
| WU-9 | Deterministic dry-run planner + SHA-256 [`compute_manifest_lock()`](scalable/planning/dryrun.py:51) | ✅ |
| WU-10 | `scalable validate` and `scalable plan --dry-run` CLI commands + Phase 1 reserved-namespace stubs | ✅ |
| WU-11 | Top-level public re-exports updated in [`scalable/__init__.py`](scalable/__init__.py:1) | ✅ |
| WU-12 | Unit + integration coverage rounded out (session, planning, CLI, exports, settings env) | ✅ |
| WU-13 | Docs: `manifest.rst`, `providers.rst`, `README` v2 quickstart, [`CHANGELOG.md`](CHANGELOG.md:1) | ✅ |
| WU-14 | CI: `validate-example-manifests` job, macOS matrix, version-branch triggers | ✅ |
| WU-15 | This PR | ✅ |

---

## Architectural changes

### New package layout

```
scalable/
  manifest/   # schema, parser, validate, adapter, errors
  providers/  # base protocol, registry, local, slurm
  session/    # ScalableSession
  planning/   # deterministic dry-run + manifest_lock
  cli/        # main, cmd_validate, cmd_plan
```

No existing modules are removed. Existing v1.1.0 imports continue to work unchanged.

### Public API surface (additive)

[`scalable/__init__.py`](scalable/__init__.py:1) now also re-exports:

- `ScalableSession`
- `DeploymentProvider`
- `LocalProvider`
- `SlurmProvider`

Legacy exports (`SlurmCluster`, `JobQueueCluster`, `ScalableClient`, `cacheable`, `SEED`, `settings`, etc.) are preserved.

### Schema and provider contracts (frozen for Phase 1)

- `scalable.yaml` schema `version: 1` enforced by [`scalable/manifest/parser.py`](scalable/manifest/parser.py:1).
- Provider-neutral types in [`scalable/providers/base.py`](scalable/providers/base.py:1): `DeploymentSpec`, `ResourceRequest`, `ScalePlan`, `ClusterHandle`, and the `DeploymentProvider` protocol.
- Provider registry in [`scalable/providers/registry.py`](scalable/providers/registry.py:1) supports runtime registration **and** entry-point discovery under group `scalable.providers` for future Phase 3 third-party providers.

### Session API (Phase 1 minimal form)

`ScalableSession.plan(...)` is purely deterministic in Phase 1. The `objective=` and `policy=` keyword arguments named in the v2 north-star are reserved on the public surface and currently raise `NotImplementedError`, locking the API shape for the Phase 4 AI planner without committing behavior.

### CLI

- `scalable validate <manifest>` — exits 0/non-zero, emits a structured JSON report.
- `scalable plan <manifest> --target <name> --dry-run --output plan.json` — writes `plan.json` and `manifest.lock` and prints the plan to stdout.
- Reserved verbs (`run`, `diagnose`, `explain`, `init-component`, `compose`, `report`) are registered as namespace stubs that exit 2 with a phase-pointer message, so the UX namespace cannot be hijacked by third-party packages.

### `manifest_lock`

SHA-256 over canonicalized JSON of the post-env-expansion manifest (sorted keys, UTF-8, compact separators). Designed to be stable so Phase 2 telemetry and Phase 4 AI assistants can durably reference manifests.

---

## Deprecations

- `ModelConfig.__init__` emits `DeprecationWarning` when invoked **outside** the manifest adapter context. This is the path slated for replacement by the manifest. Behavior is unchanged; the warning only surfaces when the legacy auto-discovery is used directly. Suppression is provided by [`model_config_adapter_context()`](scalable/utilities.py:26) for adapter-internal callers.

No other public API is deprecated in this phase.

---

## Configuration surface

- Bumped `version = "2.0.0a1"` in [`pyproject.toml`](pyproject.toml:1).
- Registered `[project.scripts] scalable = "scalable.cli.main:main"`.
- Optional extras placeholders declared (empty in Phase 1):
  - `ai`
  - `cloud`
  - `kubernetes`
- Added `pyyaml >= 6.0` to core dependencies.
- New env-var-driven settings in [`scalable/common.py`](scalable/common.py:1):
  - `SCALABLE_MANIFEST` → `Settings.manifest_path` (default `./scalable.yaml`)
  - `SCALABLE_TARGET` → `Settings.target`

---

## Documentation

- [`docs/manifest.rst`](docs/manifest.rst:1): schema v1 reference, validation/plan commands, env vars, migration note, links to examples.
- [`docs/providers.rst`](docs/providers.rst:1): provider contract, built-in providers, registry/discovery hook.
- [`docs/index.rst`](docs/index.rst:1): both pages added under the API section.
- [`docs/getting_started.rst`](docs/getting_started.rst:1): cross-link to manifest/providers.
- [`README.md`](README.md:1): manifest-first quickstart with v2 session example.
- [`CHANGELOG.md`](CHANGELOG.md:1): `2.0.0a1` entry under Keep-a-Changelog conventions.
- Example manifests:
  - [`docs/examples/scalable.minimal.yaml`](docs/examples/scalable.minimal.yaml:1)
  - [`docs/examples/scalable.gcam_stitches.yaml`](docs/examples/scalable.gcam_stitches.yaml:1)

---

## CI updates

[`.github/workflows/tests.yml`](.github/workflows/tests.yml:1):

- `push` and `pull_request` triggers now include `version/**`.
- Test matrix expanded to include macOS for Python 3.11 (LocalProvider path).
- New `validate-example-manifests` job runs `scalable validate` and `scalable plan --dry-run` against the docs examples to lock the documented manifest grammar against drift.
- `lint` (ruff + mypy) job retained; no rule changes.

---

## Test coverage

Full unit suite is green locally (`156 passed`):

```
pytest -q
........................................................................ [ 46%]
........................................................................ [ 92%]
............                                                             [100%]
156 passed in 1.04s
```

`ruff check scalable tests` is also clean.

New test modules added in this phase:

- [`tests/unit/test_manifest_parser.py`](tests/unit/test_manifest_parser.py:1) — env expansion, schema rejections, version check
- [`tests/unit/test_manifest_validate.py`](tests/unit/test_manifest_validate.py:1) — cross-field rules + multi-error accumulation
- [`tests/unit/test_providers_base_registry.py`](tests/unit/test_providers_base_registry.py:1) — registry, lazy builtin lookup
- [`tests/unit/test_providers_local.py`](tests/unit/test_providers_local.py:1) + [`tests/integration/test_local_provider_end_to_end.py`](tests/integration/test_local_provider_end_to_end.py:1)
- [`tests/unit/test_providers_slurm.py`](tests/unit/test_providers_slurm.py:1) — mocked Slurm translation
- [`tests/unit/test_manifest_adapter.py`](tests/unit/test_manifest_adapter.py:1)
- [`tests/unit/test_modelconfig_deprecation.py`](tests/unit/test_modelconfig_deprecation.py:1)
- [`tests/unit/test_planning_dryrun.py`](tests/unit/test_planning_dryrun.py:1) — deterministic `manifest_lock`
- [`tests/unit/test_session.py`](tests/unit/test_session.py:1)
- [`tests/unit/test_cli_validate.py`](tests/unit/test_cli_validate.py:1)
- [`tests/unit/test_cli_plan.py`](tests/unit/test_cli_plan.py:1)
- [`tests/unit/test_public_api_exports.py`](tests/unit/test_public_api_exports.py:1)

CLI smoke checks performed manually against the new docs examples.

---

## Backward compatibility

- All v1.1.0 imports keep working; nothing is removed.
- Existing imperative flow (`SlurmCluster(...)` → `add_container(...)` → `add_workers(...)` → `ScalableClient(cluster)`) is unchanged and remains tested.
- `ModelConfig` Dockerfile auto-discovery now warns but still functions.
- `version = "2.0.0a1"` is alpha-tagged so downstreams pinning `<2.0.0` are unaffected.

---

## Phase 1 success criteria checklist (from [`plans/v2.0.0_phase1_plan.md`](plans/v2.0.0_phase1_plan.md:1))

- [x] `from scalable import ScalableSession` works; `ScalableSession.from_yaml(..., target="local")` produces a working `LocalCluster` + `ScalableClient` capable of tagged `submit(...)`.
- [x] `ScalableSession.from_yaml(..., target="slurm")` configures `SlurmCluster` from manifest with no functional regression vs. v1.1.0 imperative path.
- [x] Existing v1.1.0 user code continues to work unchanged; only `ModelConfig` Dockerfile path emits `DeprecationWarning`.
- [x] `scalable validate` exits 0 on valid manifest, non-zero on invalid, with structured error report.
- [x] `scalable plan --dry-run --target <name>` writes `plan.json` + `manifest.lock` without instantiating a scheduler.
- [x] All new modules have unit tests; `LocalProvider` has integration coverage; existing tests remain green.
- [x] CI configured for macOS + Linux; ruff clean for new modules.
- [x] [`CHANGELOG.md`](CHANGELOG.md:1) entry, README + docs updates, migration note for `ModelConfig` users.

---

## Groundwork explicitly enabling later phases

| Phase 1 artifact | Future phase consumer |
|------------------|------------------------|
| `DeploymentProvider` protocol with provider-neutral `DeploymentSpec` / `ScalePlan` | Phase 3 (Kubernetes/cloud), Phase 4 (AI planner) |
| Provider registry with `entry_points` discovery | Phase 3 third-party providers |
| `manifest_lock` SHA-256 fingerprint | Phase 2 telemetry, Phase 4 plan explanations |
| `targets[*].options: dict[str, Any]` passthrough + unknown-key warnings | Phase 3 cloud overlays, Phase 4 migration assistant |
| `ScalableSession.plan(objective=, policy=)` reserved kwargs raising `NotImplementedError` | Phase 4 AI planner, Phase 5 ML resource advisor |
| CLI subcommand stubs (`run`, `diagnose`, `explain`, `init-component`, `compose`, `report`) | Phases 2–5 |
| Optional-dependency extras (`ai`, `cloud`, `kubernetes`) declared empty | Phases 3–5 |
| `Settings.manifest_path` / `Settings.target` + env vars | Phase 2 telemetry config, Phase 3 overlay selection |
| Manifest-to-legacy adapter as a pure function | Phase 4 onboarding assistant |

---

## Risk and rollback

- All changes are additive; rollback is a `git revert` of the squash/merge commit on `version/2.0.0` without affecting `develop`/`master`.
- Slurm provider tests are mocked and require no live cluster.
- Local provider integration test uses `processes=False, n_workers=1` to keep CI fast and macOS-stable.

---

## How to review

1. Skim [`plans/v2.0.0_phase1_plan.md`](plans/v2.0.0_phase1_plan.md:1) for the architectural intent.
2. Read protocol shapes in [`scalable/providers/base.py`](scalable/providers/base.py:1) — these are frozen for Phase 1.
3. Read the schema in [`scalable/manifest/schema.py`](scalable/manifest/schema.py:1) and [`scalable/manifest/parser.py`](scalable/manifest/parser.py:1).
4. Read `ScalableSession` in [`scalable/session/session.py`](scalable/session/session.py:1) — note the auto-target heuristic and reserved kwargs.
5. Skim CLI behavior in [`scalable/cli/main.py`](scalable/cli/main.py:1), [`scalable/cli/cmd_validate.py`](scalable/cli/cmd_validate.py:1), and [`scalable/cli/cmd_plan.py`](scalable/cli/cmd_plan.py:1).
6. Verify no regression in [`scalable/__init__.py`](scalable/__init__.py:1) re-exports.

---

## Phase 1 architecture

```mermaid
flowchart LR
    subgraph User
      U[scalable.yaml]
      CLI[scalable CLI]
      PY[ScalableSession.from_yaml]
    end

    subgraph Manifest_Layer
      P[parser]
      V[validate]
      S[schema v1]
      A[adapter]
      L[manifest_lock]
    end

    subgraph Provider_Layer
      B[DeploymentProvider Protocol]
      R[registry]
      LP[LocalProvider]
      SP[SlurmProvider]
    end

    subgraph Existing_v1_1_0
      JC[JobQueueCluster]
      SC[SlurmCluster]
      CC[ScalableClient]
    end

    U --> P --> V --> S
    P --> L
    CLI --> P
    CLI --> V
    CLI --> A
    PY --> P
    PY --> A
    A --> B
    B --> R
    R --> LP
    R --> SP
    LP --> CC
    SP --> SC --> JC
```

---

**Merge target:** `version/2.0.0`
**Source branch:** `version/2.0.0-phase1-provider-manifest`
**Tracking PR:** [#20](https://github.com/JGCRI/scalable/pull/20)