### PR TITLE
phase 2 progress towards telemetry and deterministic advising

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,52 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-No notable changes yet.
+### Added
+
+- **Phase 2 telemetry package** implementing run history, event schemas, and
+  report aggregation:
+  - `scalable.telemetry.events`
+  - `scalable.telemetry.store`
+  - `scalable.telemetry.collectors`
+  - `scalable.telemetry.runtime`
+- **Run history store** for manifest-driven sessions under `.scalable/runs/`
+  with persisted `manifest.yaml`, `plan.json`, `manifest.lock`, `run.json`,
+  task/resource/worker/failure/cache/artifact JSONL streams, and `summary.json`.
+- **`scalable report` CLI command** (text + JSON output) replacing the Phase 1
+  report stub.
+- **Deterministic advising API**:
+  - `ResourceAdvisor.from_history(...)`
+  - `ResourceAdvisor.recommend(...)`
+  - `ResourceRecommendation` result payload
+- **Artifact metadata recording API** via `ScalableSession.record_artifact(...)`.
+- New docs pages:
+  - `docs/telemetry.rst`
+  - `docs/advising.rst`
+
+### Changed
+
+- `ScalableSession` now initializes and finalizes telemetry by default for
+  manifest-driven runs (configurable).
+- `ScalableClient.submit` and `ScalableClient.map` now emit task lifecycle
+  telemetry through future callbacks.
+- `cacheable` now emits cache hit/miss telemetry events when telemetry is
+  active.
+- `LocalProvider` and `SlurmProvider` now emit worker/cluster telemetry events.
+- `scalable.__all__` now exports `ResourceAdvisor` and
+  `ResourceRecommendation`.
+- `Settings` now includes telemetry controls:
+  - `runs_dir` (`SCALABLE_RUNS_DIR`)
+  - `telemetry_enabled` (`SCALABLE_TELEMETRY`)
+  - `telemetry_parquet` (`SCALABLE_TELEMETRY_PARQUET`)
+
+### Tests
+
+- Added unit and integration coverage for:
+  - telemetry store lifecycle and summary generation
+  - telemetry collectors and report rendering
+  - `scalable report` CLI behavior
+  - `ResourceAdvisor` heuristics and fallbacks
+  - session telemetry end-to-end behavior on local execution
 
 ## [2.0.0a1] - 2026-05-19
 

--- a/README.md
+++ b/README.md
@@ -114,6 +114,13 @@ scalable validate ./scalable.yaml
 scalable plan ./scalable.yaml --target local --dry-run --output plan.json
 ```
 
+Generate a telemetry report from completed runs:
+
+```bash
+scalable report --latest
+scalable report --latest --format json --output report.json
+```
+
 Use the session API:
 
 ```python
@@ -122,6 +129,21 @@ from scalable import ScalableSession
 session = ScalableSession.from_yaml("./scalable.yaml", target="local")
 plan = session.plan(dry_run=True)
 print(plan.manifest_lock)
+```
+
+Use deterministic history-based advising:
+
+```python
+from scalable import ResourceAdvisor
+
+advisor = ResourceAdvisor.from_history("./.scalable/runs")
+recommendation = advisor.recommend(
+    task="run_gcam",
+    target="local",
+    confidence=0.95,
+)
+print(recommendation.workers)
+print(recommendation.resources)
 ```
 
 At runtime, create a cluster, register container targets, scale workers, and submit functions.

--- a/docs/advising.rst
+++ b/docs/advising.rst
@@ -1,0 +1,31 @@
+Deterministic Resource Advising
+==============================
+
+Phase 2 adds a baseline deterministic :class:`ResourceAdvisor` that derives
+conservative resource recommendations from historical run telemetry.
+
+Quick start
+-----------
+
+.. code-block:: python
+
+    from scalable import ResourceAdvisor
+
+    advisor = ResourceAdvisor.from_history("./.scalable/runs")
+    recommendation = advisor.recommend(
+        task="run_gcam",
+        target="local",
+        confidence=0.95,
+    )
+
+    print(recommendation.workers)
+    print(recommendation.resources)
+    print(recommendation.evidence)
+
+Design intent
+-------------
+
+This advisor is heuristic and explainable. It uses observed request/runtime
+history and confidence-indexed quantiles. Learned ML models are deferred to
+later phases.
+

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -96,6 +96,8 @@ Next Steps
 After setup:
 
 * For declarative workflows, start with :doc:`manifest` and :doc:`providers`.
+* Review run telemetry in :doc:`telemetry`.
+* Use deterministic history-based recommendations from :doc:`advising`.
 * Review the :ref:`api_section` for worker, caching, and function interfaces.
 * Run examples from :ref:`demos_section`.
 * Use :ref:`how_tos_section` for targeted implementation guidance.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -47,6 +47,8 @@ Contents
    workers
    manifest
    providers
+   telemetry
+   advising
    caching
    functions
 

--- a/docs/telemetry.rst
+++ b/docs/telemetry.rst
@@ -1,0 +1,55 @@
+Telemetry and Run Reports
+=========================
+
+Phase 2 introduces a deterministic run history store for manifest-driven
+sessions.
+
+Run directory layout
+--------------------
+
+Each run is recorded under ``.scalable/runs/``:
+
+.. code-block:: text
+
+    .scalable/
+      runs/
+        run-.../
+          manifest.yaml
+          plan.json
+          manifest.lock
+          run.json
+          tasks.jsonl
+          resources.jsonl
+          workers.jsonl
+          failures.jsonl
+          cache.jsonl
+          artifacts.jsonl
+          summary.json
+
+JSONL is the canonical storage format. Optional parquet snapshots are emitted
+when telemetry parquet support is enabled.
+
+CLI reporting
+-------------
+
+Generate a report from the most recent run:
+
+.. code-block:: bash
+
+    scalable report --latest
+
+Machine-readable report output:
+
+.. code-block:: bash
+
+    scalable report --latest --format json --output report.json
+
+Configuration
+-------------
+
+The telemetry system supports these environment variables:
+
+* ``SCALABLE_RUNS_DIR``
+* ``SCALABLE_TELEMETRY``
+* ``SCALABLE_TELEMETRY_PARQUET``
+

--- a/scalable/__init__.py
+++ b/scalable/__init__.py
@@ -19,6 +19,7 @@ from importlib.metadata import version as _pkg_version
 from dask.distributed import Security  # noqa: F401  (re-exported for users)
 from distributed import get_worker  # noqa: F401  (re-exported for users)
 
+from .advising import ResourceAdvisor, ResourceRecommendation
 from .caching import *  # noqa: F401,F403  (legacy star-export)
 from .client import ScalableClient
 from .common import SEED, settings
@@ -37,6 +38,8 @@ __all__ = [
     "DeploymentProvider",
     "LocalProvider",
     "SEED",
+    "ResourceAdvisor",
+    "ResourceRecommendation",
     "ScalableClient",
     "ScalableSession",
     "Security",

--- a/scalable/advising/__init__.py
+++ b/scalable/advising/__init__.py
@@ -1,0 +1,8 @@
+"""Deterministic advising APIs for Phase 2."""
+
+from __future__ import annotations
+
+from .resources import ResourceAdvisor, ResourceRecommendation
+
+__all__ = ["ResourceAdvisor", "ResourceRecommendation"]
+

--- a/scalable/advising/resources.py
+++ b/scalable/advising/resources.py
@@ -1,0 +1,196 @@
+"""Deterministic, explainable resource recommendations from run telemetry."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+from dask.utils import parse_bytes
+
+from scalable.telemetry.collectors import iter_run_dirs, read_jsonl
+
+
+def _memory_to_bytes(value: str | None) -> int | None:
+    if value is None:
+        return None
+    try:
+        parsed = int(parse_bytes(value))
+    except Exception:
+        return None
+    if parsed <= 0:
+        return None
+    return parsed
+
+
+def _bytes_to_gib_string(value: int | None) -> str | None:
+    if value is None or value <= 0:
+        return None
+    gib = (value + (1024**3 - 1)) // (1024**3)
+    return f"{int(gib)}G"
+
+
+def _seconds_to_hhmmss(seconds: float | None) -> str | None:
+    if seconds is None or seconds <= 0:
+        return None
+    total = int(round(seconds))
+    hours = total // 3600
+    minutes = (total % 3600) // 60
+    secs = total % 60
+    return f"{hours:02d}:{minutes:02d}:{secs:02d}"
+
+
+@dataclass(frozen=True)
+class ResourceRecommendation:
+    """Explainable recommendation payload returned by :class:`ResourceAdvisor`."""
+
+    task: str
+    target: str | None
+    confidence: float
+    workers: dict[str, int]
+    resources: dict[str, dict[str, Any]]
+    evidence: dict[str, Any]
+
+
+class ResourceAdvisor:
+    """Heuristic advisor using historical quantiles from telemetry."""
+
+    def __init__(self, records: pd.DataFrame) -> None:
+        self._records = records.copy()
+
+    @classmethod
+    def from_history(cls, runs_dir: str | Path) -> ResourceAdvisor:
+        """Build advisor state from telemetry run directories."""
+        rows: list[dict[str, Any]] = []
+
+        for run_dir in iter_run_dirs(runs_dir):
+            run_json = run_dir / "run.json"
+            if not run_json.exists():
+                continue
+            run_meta = pd.read_json(run_json, typ="series")
+            run_id = str(run_meta.get("run_id", run_dir.name))
+            target_name = run_meta.get("target_name")
+
+            task_rows = read_jsonl(run_dir / "tasks.jsonl")
+            resource_rows = read_jsonl(run_dir / "resources.jsonl")
+
+            resources_by_task: dict[str, dict[str, Any]] = {}
+            for r in resource_rows:
+                if r.get("entity_type") != "task":
+                    continue
+                entity = str(r.get("entity_id", ""))
+                if not entity:
+                    continue
+                resources_by_task[entity] = r
+
+            for t in task_rows:
+                if t.get("state") not in {"succeeded", "failed", "cancelled"}:
+                    continue
+                task_id = str(t.get("task_id", ""))
+                if not task_id:
+                    continue
+
+                resources = resources_by_task.get(task_id, {})
+                rows.append(
+                    {
+                        "run_id": run_id,
+                        "target": target_name,
+                        "task_id": task_id,
+                        "task_name": t.get("task_name"),
+                        "component": t.get("component"),
+                        "state": t.get("state"),
+                        "duration_s": t.get("duration_s"),
+                        "requested_workers": resources.get("requested_workers"),
+                        "requested_cpus": resources.get("requested_cpus"),
+                        "requested_memory": resources.get("requested_memory"),
+                        "requested_memory_bytes": _memory_to_bytes(resources.get("requested_memory")),
+                        "requested_walltime": resources.get("requested_walltime"),
+                    }
+                )
+
+        frame = pd.DataFrame(rows)
+        return cls(frame)
+
+    def recommend(
+        self,
+        *,
+        task: str,
+        input_features: dict[str, Any] | None = None,
+        target: str | None = None,
+        confidence: float = 0.95,
+    ) -> ResourceRecommendation:
+        """Recommend workers/resources using confidence-indexed quantiles."""
+        _ = input_features  # reserved for Phase 5 learned models
+
+        q = min(max(float(confidence), 0.5), 0.99)
+        frame = self._records
+        if frame.empty:
+            return ResourceRecommendation(
+                task=task,
+                target=target,
+                confidence=q,
+                workers={task: 1},
+                resources={task: {"cpus": 1, "memory": None, "walltime": None}},
+                evidence={"records": 0, "reason": "no history"},
+            )
+
+        scoped = frame[frame["task_name"] == task]
+        if target is not None and not scoped.empty:
+            scoped_target = scoped[scoped["target"] == target]
+            if not scoped_target.empty:
+                scoped = scoped_target
+
+        if scoped.empty:
+            return ResourceRecommendation(
+                task=task,
+                target=target,
+                confidence=q,
+                workers={task: 1},
+                resources={task: {"cpus": 1, "memory": None, "walltime": None}},
+                evidence={"records": 0, "reason": "task not found in history"},
+            )
+
+        component = scoped["component"].dropna().iloc[-1] if scoped["component"].notna().any() else task
+        component = str(component)
+
+        workers_series = pd.to_numeric(scoped["requested_workers"], errors="coerce").dropna()
+        cpus_series = pd.to_numeric(scoped["requested_cpus"], errors="coerce").dropna()
+        duration_series = pd.to_numeric(scoped["duration_s"], errors="coerce").dropna()
+        mem_series = pd.to_numeric(scoped["requested_memory_bytes"], errors="coerce").dropna()
+
+        workers = int(max(1, round(float(workers_series.quantile(q))))) if not workers_series.empty else 1
+        cpus = int(max(1, round(float(cpus_series.quantile(q))))) if not cpus_series.empty else 1
+
+        memory_bytes = int(mem_series.quantile(q)) if not mem_series.empty else None
+        if memory_bytes is not None:
+            memory_bytes = int(memory_bytes * 1.10)
+        walltime_seconds = float(duration_series.quantile(q) * 1.20) if not duration_series.empty else None
+
+        memory = _bytes_to_gib_string(memory_bytes)
+        walltime = _seconds_to_hhmmss(walltime_seconds)
+
+        evidence = {
+            "records": int(len(scoped.index)),
+            "quantile": q,
+            "component": component,
+            "state_counts": scoped["state"].value_counts().to_dict(),
+        }
+
+        return ResourceRecommendation(
+            task=task,
+            target=target,
+            confidence=q,
+            workers={component: workers},
+            resources={
+                component: {
+                    "cpus": cpus,
+                    "memory": memory,
+                    "walltime": walltime,
+                }
+            },
+            evidence=evidence,
+        )
+
+
+__all__ = ["ResourceAdvisor", "ResourceRecommendation"]

--- a/scalable/caching.py
+++ b/scalable/caching.py
@@ -2,6 +2,7 @@ import functools
 import hashlib
 import os
 import pickle
+import time
 import types
 import warnings
 from collections.abc import Callable
@@ -14,6 +15,7 @@ from diskcache import Cache
 from xxhash import xxh32
 
 from .common import logger, settings
+from .telemetry.runtime import emit_cache_event
 
 
 def _seed() -> int:
@@ -391,6 +393,7 @@ def cacheable(
             key = hash(ObjectType(sorted(keys)))
             disk = _shared_cache(_cache_dir())
             ret = None
+            lookup_start = time.monotonic()
             if key in disk and not recompute:
                 value = disk.get(key)
                 if value is None:
@@ -413,7 +416,14 @@ def cacheable(
                         )
                 else:
                     ret = stored_value
+                emit_cache_event(
+                    function_name=getattr(func, "__qualname__", func.__name__),
+                    key_digest=str(key),
+                    hit=True,
+                    duration_s=max(time.monotonic() - lookup_start, 0.0),
+                )
             if ret is None:
+                compute_start = time.monotonic()
                 ret = func(*args, **kwargs)
                 if store:
                     if return_type is None:
@@ -424,6 +434,12 @@ def cacheable(
                         logger.warning(
                             "%s could not be added to cache.", func.__name__
                         )
+                emit_cache_event(
+                    function_name=getattr(func, "__qualname__", func.__name__),
+                    key_digest=str(key),
+                    hit=False,
+                    duration_s=max(time.monotonic() - compute_start, 0.0),
+                )
             return ret
 
         return func if void else inner

--- a/scalable/cli/__init__.py
+++ b/scalable/cli/__init__.py
@@ -1,11 +1,13 @@
-"""``scalable`` console-script CLI (v2.0.0 Phase 1).
+"""``scalable`` console-script CLI (v2.0.0 Phase 2).
 
-Phase 1 implements two subcommands -- ``scalable validate`` and
-``scalable plan --dry-run`` -- both of which operate purely on a manifest
-plus provider abstractions and never instantiate a scheduler.
+Implemented subcommands:
+
+* ``scalable validate``
+* ``scalable plan --dry-run``
+* ``scalable report``
 
 The remaining subcommand namespace (``run``, ``diagnose``, ``explain``,
-``init-component``, ``compose``, ``report``) is registered as Phase 1 stubs
+``init-component``, ``compose``) is registered as explicit stubs
 that print a phase-pointer message on invocation. This locks the UX
 namespace early so third-party CLIs don't collide with future Scalable
 verbs and so Phases 2-5 only fill behaviour rather than surface.

--- a/scalable/cli/cmd_report.py
+++ b/scalable/cli/cmd_report.py
@@ -1,0 +1,47 @@
+"""Implementation for ``scalable report``."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+from scalable.telemetry.collectors import render_text_report, resolve_run_dir, summarize_run
+
+
+def run_report(
+    *,
+    runs_dir: str,
+    run_id: str | None,
+    latest: bool,
+    fmt: str,
+    output: str | None,
+) -> int:
+    """Load telemetry for one run and emit a report payload."""
+    try:
+        run_dir = resolve_run_dir(runs_dir=runs_dir, run_id=run_id, latest=latest)
+    except (FileNotFoundError, ValueError) as exc:
+        print(f"report failed: {exc}", file=sys.stderr)
+        return 1
+
+    summary = summarize_run(run_dir)
+
+    if fmt == "json":
+        rendered = json.dumps(summary, indent=2, sort_keys=True)
+    elif fmt == "text":
+        rendered = render_text_report(summary)
+    else:
+        print(f"report failed: unsupported format {fmt!r}", file=sys.stderr)
+        return 2
+
+    if output:
+        output_path = Path(output)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(rendered + "\n", encoding="utf-8")
+
+    print(rendered, file=sys.stdout)
+    return 0
+
+
+__all__ = ["run_report"]
+

--- a/scalable/cli/main.py
+++ b/scalable/cli/main.py
@@ -1,12 +1,13 @@
 """``scalable`` console entry-point dispatcher.
 
-Phase 1 ships two implemented subcommands:
+Implemented subcommands:
 
 * ``scalable validate``
 * ``scalable plan --dry-run``
+* ``scalable report``
 
-The namespace for later-phase verbs (``run``, ``diagnose``, ``explain``,
-``init-component``, ``compose``, ``report``) is reserved as explicit stubs.
+The remaining namespace for later-phase verbs (``run``, ``diagnose``,
+``explain``, ``init-component``, ``compose``) is reserved as explicit stubs.
 """
 
 from __future__ import annotations
@@ -17,6 +18,7 @@ import sys
 from scalable.common import settings
 
 from .cmd_plan import run_plan
+from .cmd_report import run_report
 from .cmd_validate import run_validate
 
 _STUB_COMMANDS: dict[str, str] = {
@@ -25,7 +27,6 @@ _STUB_COMMANDS: dict[str, str] = {
     "explain": "Phase 4",
     "init-component": "Phase 4",
     "compose": "Phase 4",
-    "report": "Phase 2",
 }
 
 
@@ -38,6 +39,16 @@ def _handle_plan(args: argparse.Namespace) -> int:
         args.manifest,
         target=args.target,
         dry_run=bool(args.dry_run),
+        output=args.output,
+    )
+
+
+def _handle_report(args: argparse.Namespace) -> int:
+    return run_report(
+        runs_dir=args.runs_dir,
+        run_id=args.run_id,
+        latest=bool(args.latest),
+        fmt=args.format,
         output=args.output,
     )
 
@@ -100,6 +111,38 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Plan output path (default: ./plan.json)",
     )
     plan_parser.set_defaults(handler=_handle_plan)
+
+    report_parser = subparsers.add_parser(
+        "report",
+        help="Summarize telemetry for a completed or running session",
+    )
+    report_parser.add_argument(
+        "--runs-dir",
+        default=settings.runs_dir,
+        help="Runs directory (default: SCALABLE_RUNS_DIR or ./.scalable/runs)",
+    )
+    report_parser.add_argument(
+        "--run-id",
+        default=None,
+        help="Explicit run directory name (e.g. run-20260519T120000Z-...)",
+    )
+    report_parser.add_argument(
+        "--latest",
+        action="store_true",
+        help="Select the most recent run in --runs-dir",
+    )
+    report_parser.add_argument(
+        "--format",
+        choices=["text", "json"],
+        default="text",
+        help="Output format",
+    )
+    report_parser.add_argument(
+        "--output",
+        default=None,
+        help="Optional output file path",
+    )
+    report_parser.set_defaults(handler=_handle_report)
 
     for command, phase in _STUB_COMMANDS.items():
         stub_parser = subparsers.add_parser(command, help=f"Reserved command (planned for {phase})")

--- a/scalable/client.py
+++ b/scalable/client.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import functools
+import time
+import uuid
 from collections.abc import Iterable
 from typing import Any
 
@@ -10,6 +13,7 @@ from distributed import Client
 from distributed.diagnostics.plugin import SchedulerPlugin
 
 from .slurm import SlurmCluster
+from .telemetry.runtime import task_context
 
 
 class SlurmSchedulerPlugin(SchedulerPlugin):
@@ -39,8 +43,74 @@ class ScalableClient(Client):
     def __init__(self, cluster: Any, *args: Any, **kwargs: Any) -> None:
         """Initialize a client bound to an existing cluster/scheduler."""
         super().__init__(address=cluster, *args, **kwargs)
+        self._telemetry_store = None
         if isinstance(cluster, SlurmCluster):
             self.register_scheduler_plugin(SlurmSchedulerPlugin(None))
+
+    def set_telemetry_store(self, store: Any) -> None:
+        """Attach an active telemetry store for task lifecycle instrumentation."""
+        self._telemetry_store = store
+
+    def _record_future(
+        self,
+        *,
+        future: Any,
+        task_id: str,
+        task_name: str,
+        component: str | None,
+        tag: str | None,
+        function_name: str,
+        requested_workers: int,
+        submitted_at: float,
+    ) -> None:
+        store = self._telemetry_store
+        if store is None:
+            return
+
+        store.record_task_submission(
+            task_id=task_id,
+            task_name=task_name,
+            component=component,
+            tag=tag,
+            function_name=function_name,
+            requested_workers=requested_workers,
+        )
+
+        def _on_done(done_future: Any) -> None:
+            state = "succeeded"
+            worker = getattr(done_future, "key", None)
+            error_type = None
+            error_message = None
+
+            try:
+                if done_future.cancelled():
+                    state = "cancelled"
+                else:
+                    exc = done_future.exception()
+                    if exc is not None:
+                        state = "failed"
+                        error_type = type(exc).__name__
+                        error_message = str(exc)
+            except Exception as callback_exc:  # pragma: no cover - defensive
+                state = "failed"
+                error_type = type(callback_exc).__name__
+                error_message = str(callback_exc)
+
+            _ = submitted_at
+            store.record_task_result(
+                task_id=task_id,
+                task_name=task_name,
+                component=component,
+                tag=tag,
+                function_name=function_name,
+                requested_workers=requested_workers,
+                state=state,
+                worker=worker,
+                error_type=error_type,
+                error_message=error_message,
+            )
+
+        future.add_done_callback(_on_done)
 
     def submit(
         self,
@@ -88,7 +158,29 @@ class ScalableClient(Client):
         resources = None
         if tag is not None:
             resources = {tag: n}
-        return super().submit(func, resources=resources, *args, **kwargs)
+
+        task_name = str(kwargs.pop("_scalable_task_name", getattr(func, "__name__", "task")))
+        function_name = getattr(func, "__qualname__", getattr(func, "__name__", repr(func)))
+
+        @functools.wraps(func)
+        def _wrapped(*wrapped_args: Any, **wrapped_kwargs: Any) -> Any:
+            with task_context(task_name=task_name, component=tag, tag=tag):
+                return func(*wrapped_args, **wrapped_kwargs)
+
+        submitted_at = time.monotonic()
+        future = super().submit(_wrapped, resources=resources, *args, **kwargs)
+
+        self._record_future(
+            future=future,
+            task_id=uuid.uuid4().hex,
+            task_name=task_name,
+            component=tag,
+            tag=tag,
+            function_name=function_name,
+            requested_workers=n,
+            submitted_at=submitted_at,
+        )
+        return future
     
     def cancel(self, futures: Any, *args: Any, **kwargs: Any) -> Any:
         """
@@ -168,7 +260,29 @@ class ScalableClient(Client):
         resources = None
         if tag is not None:
             resources = {tag: n}
-        return super().map(func, *parameters, resources=resources, **kwargs)
+        base_task_name = str(kwargs.pop("_scalable_task_name", getattr(func, "__name__", "task")))
+        function_name = getattr(func, "__qualname__", getattr(func, "__name__", repr(func)))
+
+        @functools.wraps(func)
+        def _wrapped(*wrapped_args: Any, **wrapped_kwargs: Any) -> Any:
+            with task_context(task_name=base_task_name, component=tag, tag=tag):
+                return func(*wrapped_args, **wrapped_kwargs)
+
+        submitted_at = time.monotonic()
+        futures = super().map(_wrapped, *parameters, resources=resources, **kwargs)
+
+        for index, future in enumerate(futures):
+            self._record_future(
+                future=future,
+                task_id=uuid.uuid4().hex,
+                task_name=f"{base_task_name}[{index}]",
+                component=tag,
+                tag=tag,
+                function_name=function_name,
+                requested_workers=n,
+                submitted_at=submitted_at,
+            )
+        return futures
     
     def get_versions(
         self, check: bool = False, packages: list[str] | None = None

--- a/scalable/common.py
+++ b/scalable/common.py
@@ -31,6 +31,7 @@ __all__ = ["logger", "settings", "Settings", "SEED", "cachedir", "DEFAULT_SEED"]
 DEFAULT_SEED: int = 987654321
 DEFAULT_CACHE_DIR: str = "./cache"
 DEFAULT_MANIFEST_PATH: str = "./scalable.yaml"
+DEFAULT_RUNS_DIR: str = "./.scalable/runs"
 
 
 @dataclass
@@ -56,6 +57,15 @@ class Settings:
         default_factory=lambda: os.environ.get("SCALABLE_MANIFEST", DEFAULT_MANIFEST_PATH)
     )
     target: str | None = field(default_factory=lambda: os.environ.get("SCALABLE_TARGET"))
+    runs_dir: str = field(
+        default_factory=lambda: os.environ.get("SCALABLE_RUNS_DIR", DEFAULT_RUNS_DIR)
+    )
+    telemetry_enabled: bool = field(
+        default_factory=lambda: bool(int(os.environ.get("SCALABLE_TELEMETRY", "1")))
+    )
+    telemetry_parquet: bool = field(
+        default_factory=lambda: bool(int(os.environ.get("SCALABLE_TELEMETRY_PARQUET", "0")))
+    )
 
 
 #: Process-wide settings singleton. Mutating attributes on this instance

--- a/scalable/providers/local.py
+++ b/scalable/providers/local.py
@@ -8,6 +8,7 @@ from distributed import LocalCluster
 
 from scalable.client import ScalableClient
 from scalable.manifest.validate import ValidationIssue, ValidationReport, validate_manifest
+from scalable.telemetry.runtime import emit_worker_event
 
 from .base import ClusterHandle, DeploymentProvider, DeploymentSpec, ScalePlan
 
@@ -133,6 +134,16 @@ class LocalProvider(DeploymentProvider):
             resources=worker_resources,
         )
 
+        emit_worker_event(
+            provider=self.name,
+            state="cluster_created",
+            details={
+                "n_workers": n_workers,
+                "threads_per_worker": threads_per_worker,
+                "processes": processes,
+            },
+        )
+
         def _client_factory() -> ScalableClient:
             return ScalableClient(cluster)
 
@@ -157,11 +168,20 @@ class LocalProvider(DeploymentProvider):
         if plan.workers_by_tag:
             target_workers = sum(max(int(n), 0) for n in plan.workers_by_tag.values())
             backend.scale(target_workers)
+            emit_worker_event(
+                provider=self.name,
+                state="scaled",
+                details={
+                    "target_workers": target_workers,
+                    "workers_by_tag": dict(plan.workers_by_tag),
+                },
+            )
 
     def close(self, cluster: ClusterHandle) -> None:
         backend = cluster.backend
         if hasattr(backend, "close"):
             backend.close()
+        emit_worker_event(provider=self.name, state="cluster_closed", details={})
 
 
 def _debug_options_snapshot(options: dict[str, Any]) -> dict[str, Any]:

--- a/scalable/providers/slurm.py
+++ b/scalable/providers/slurm.py
@@ -17,6 +17,7 @@ from scalable.manifest.adapter import (
 )
 from scalable.manifest.validate import ValidationIssue, ValidationReport, validate_manifest
 from scalable.slurm import SlurmCluster
+from scalable.telemetry.runtime import emit_worker_event
 
 from .base import ClusterHandle, DeploymentProvider, DeploymentSpec, ScalePlan
 
@@ -123,6 +124,14 @@ class SlurmProvider(DeploymentProvider):
 
             return ScalableClient(cluster)
 
+        emit_worker_event(
+            provider=self.name,
+            state="cluster_created",
+            details={
+                "cluster_kwargs": {k: v for k, v in cluster_kwargs.items() if v is not None},
+            },
+        )
+
         return ClusterHandle(
             backend=cluster,
             client_factory=_client_factory,
@@ -142,11 +151,18 @@ class SlurmProvider(DeploymentProvider):
             n = int(count)
             if n > 0:
                 backend.add_workers(tag=tag, n=n)
+                emit_worker_event(
+                    provider=self.name,
+                    state="add_workers",
+                    component=tag,
+                    details={"n": n},
+                )
 
     def close(self, cluster: ClusterHandle) -> None:
         backend = cluster.backend
         if hasattr(backend, "close"):
             backend.close()
+        emit_worker_event(provider=self.name, state="cluster_closed", details={})
 
 
 def _require_type(

--- a/scalable/session/session.py
+++ b/scalable/session/session.py
@@ -14,6 +14,8 @@ from scalable.manifest.validate import ValidationIssue, ValidationReport, valida
 from scalable.planning.dryrun import DryRunPlan, build_dry_run_plan
 from scalable.providers.base import ClusterHandle, DeploymentSpec
 from scalable.providers.registry import get_provider, iter_provider_names
+from scalable.telemetry.runtime import reset_active_store, set_active_store
+from scalable.telemetry.store import TelemetryStore
 
 __all__ = ["ScalableSession"]
 
@@ -29,6 +31,8 @@ class ScalableSession:
     _provider: Any = None
     _cluster: ClusterHandle | None = None
     _client: ScalableClient | None = None
+    _telemetry: TelemetryStore | None = None
+    _telemetry_token: Any = None
 
     @classmethod
     def from_yaml(
@@ -99,25 +103,117 @@ class ScalableSession:
                 f"plan target {plan.target_name!r} does not match session target {self.target_name!r}"
             )
 
-        self._provider = get_provider(self.spec.provider_name)
-        self._cluster = self._provider.build_cluster(self.spec)
-        self._provider.scale(self._cluster, plan.scale_plan)
-        self._client = self._cluster.client_factory()
-        return self._client
+        if settings.telemetry_enabled:
+            self._telemetry = TelemetryStore.create(
+                runs_dir=settings.runs_dir,
+                manifest=self.manifest,
+                spec=self.spec,
+                plan=plan,
+                telemetry_parquet=settings.telemetry_parquet,
+            )
+            self._telemetry_token = set_active_store(self._telemetry)
+
+        try:
+            self._provider = get_provider(self.spec.provider_name)
+            self._cluster = self._provider.build_cluster(self.spec)
+            self._provider.scale(self._cluster, plan.scale_plan)
+            self._client = self._cluster.client_factory()
+            if self._telemetry is not None:
+                self._client.set_telemetry_store(self._telemetry)
+            return self._client
+        except Exception as exc:
+            if self._telemetry is not None:
+                self._telemetry.record_failure(
+                    failure_class=type(exc).__name__,
+                    message=str(exc),
+                    details={"phase": "session.start"},
+                )
+                self._telemetry.close(status="failed")
+                self._telemetry = None
+            if self._telemetry_token is not None:
+                reset_active_store(self._telemetry_token)
+                self._telemetry_token = None
+            raise
 
     def close(self) -> None:
+        close_error: Exception | None = None
+        status = "completed"
+
         if self._client is not None:
-            self._client.close()
-            self._client = None
+            try:
+                self._client.close()
+            except Exception as exc:  # pragma: no cover - defensive
+                close_error = exc
+                status = "failed"
+                if self._telemetry is not None:
+                    self._telemetry.record_failure(
+                        failure_class=type(exc).__name__,
+                        message=str(exc),
+                        details={"phase": "session.close.client"},
+                    )
+            finally:
+                self._client = None
 
         if self._cluster is not None and self._provider is not None:
-            self._provider.close(self._cluster)
-            self._cluster = None
+            try:
+                self._provider.close(self._cluster)
+            except Exception as exc:  # pragma: no cover - defensive
+                close_error = exc
+                status = "failed"
+                if self._telemetry is not None:
+                    self._telemetry.record_failure(
+                        failure_class=type(exc).__name__,
+                        message=str(exc),
+                        details={"phase": "session.close.provider"},
+                    )
+            finally:
+                self._cluster = None
+
+        if self._telemetry is not None:
+            self._telemetry.close(status=status)
+            self._telemetry = None
+
+        if self._telemetry_token is not None:
+            reset_active_store(self._telemetry_token)
+            self._telemetry_token = None
+
+        if close_error is not None:
+            raise close_error
+
+    def record_artifact(
+        self,
+        *,
+        task_name: str,
+        artifact_name: str,
+        location: str,
+        component: str | None = None,
+        kind: str | None = None,
+        size_bytes: int | None = None,
+        digest: str | None = None,
+    ) -> None:
+        """Record artifact metadata for the active run, if telemetry is enabled."""
+        if self._telemetry is None:
+            return
+        self._telemetry.record_artifact(
+            task_name=task_name,
+            component=component,
+            artifact_name=artifact_name,
+            location=location,
+            kind=kind,
+            size_bytes=size_bytes,
+            digest=digest,
+        )
 
     def __enter__(self) -> ScalableClient:
         return self.start()
 
     def __exit__(self, exc_type, exc, tb) -> None:
+        if exc is not None and self._telemetry is not None:
+            self._telemetry.record_failure(
+                failure_class=type(exc).__name__,
+                message=str(exc),
+                details={"phase": "session.context"},
+            )
         self.close()
 
 

--- a/scalable/telemetry/__init__.py
+++ b/scalable/telemetry/__init__.py
@@ -1,0 +1,56 @@
+"""Phase 2 telemetry package public exports."""
+
+from __future__ import annotations
+
+from .collectors import (
+    iter_run_dirs,
+    latest_run_dir,
+    read_jsonl,
+    render_text_report,
+    resolve_run_dir,
+    summarize_run,
+)
+from .events import (
+    ArtifactEvent,
+    CacheEvent,
+    FailureEvent,
+    ResourceEvent,
+    RunMetadata,
+    TaskEvent,
+    WorkerEvent,
+)
+from .runtime import (
+    emit_cache_event,
+    emit_worker_event,
+    get_active_store,
+    get_task_context,
+    reset_active_store,
+    set_active_store,
+    task_context,
+)
+from .store import TelemetryStore
+
+__all__ = [
+    "ArtifactEvent",
+    "CacheEvent",
+    "FailureEvent",
+    "ResourceEvent",
+    "RunMetadata",
+    "TaskEvent",
+    "TelemetryStore",
+    "WorkerEvent",
+    "emit_cache_event",
+    "emit_worker_event",
+    "get_active_store",
+    "get_task_context",
+    "iter_run_dirs",
+    "latest_run_dir",
+    "read_jsonl",
+    "render_text_report",
+    "reset_active_store",
+    "resolve_run_dir",
+    "set_active_store",
+    "summarize_run",
+    "task_context",
+]
+

--- a/scalable/telemetry/collectors.py
+++ b/scalable/telemetry/collectors.py
@@ -1,0 +1,174 @@
+"""Telemetry run loading and summary aggregation helpers."""
+
+from __future__ import annotations
+
+import json
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+
+def read_jsonl(path: Path) -> list[dict[str, Any]]:
+    """Read a newline-delimited JSON file. Missing files return an empty list."""
+    if not path.exists():
+        return []
+    rows: list[dict[str, Any]] = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        rows.append(json.loads(line))
+    return rows
+
+
+def iter_run_dirs(runs_dir: str | Path) -> list[Path]:
+    """Return existing run directories in lexicographic order."""
+    root = Path(runs_dir)
+    if not root.exists():
+        return []
+    return sorted([p for p in root.iterdir() if p.is_dir() and p.name.startswith("run-")])
+
+
+def latest_run_dir(runs_dir: str | Path) -> Path:
+    """Return the most recent run directory by lexicographic order."""
+    runs = iter_run_dirs(runs_dir)
+    if not runs:
+        raise FileNotFoundError(f"no run directories found in {Path(runs_dir)!s}")
+    return runs[-1]
+
+
+def resolve_run_dir(
+    *,
+    runs_dir: str | Path,
+    run_id: str | None = None,
+    latest: bool = False,
+) -> Path:
+    """Resolve a run directory from explicit id or latest selection."""
+    root = Path(runs_dir)
+    if run_id is not None:
+        candidate = root / run_id
+        if not candidate.exists() or not candidate.is_dir():
+            raise FileNotFoundError(f"run id {run_id!r} does not exist in {root!s}")
+        return candidate
+    if latest:
+        return latest_run_dir(root)
+    raise ValueError("must provide run_id or latest=True")
+
+
+def summarize_run(run_dir: str | Path) -> dict[str, Any]:
+    """Build a deterministic summary payload for one run directory."""
+    run_path = Path(run_dir)
+    run_meta = {}
+    run_json = run_path / "run.json"
+    if run_json.exists():
+        run_meta = json.loads(run_json.read_text(encoding="utf-8"))
+
+    tasks = read_jsonl(run_path / "tasks.jsonl")
+    resources = read_jsonl(run_path / "resources.jsonl")
+    workers = read_jsonl(run_path / "workers.jsonl")
+    failures = read_jsonl(run_path / "failures.jsonl")
+    caches = read_jsonl(run_path / "cache.jsonl")
+    artifacts = read_jsonl(run_path / "artifacts.jsonl")
+
+    final_state_by_task: dict[str, str] = {}
+    duration_values: list[float] = []
+    for row in tasks:
+        task_id = str(row.get("task_id", ""))
+        state = str(row.get("state", "unknown"))
+        if task_id:
+            final_state_by_task[task_id] = state
+        duration = row.get("duration_s")
+        if isinstance(duration, (int, float)) and duration >= 0:
+            duration_values.append(float(duration))
+
+    state_counter = Counter(final_state_by_task.values())
+    failure_counter = Counter(str(f.get("failure_class", "unknown")) for f in failures)
+    cache_hits = sum(1 for c in caches if bool(c.get("hit")))
+    cache_misses = sum(1 for c in caches if not bool(c.get("hit")))
+
+    requested_cpus: list[int] = []
+    for row in resources:
+        value = row.get("requested_cpus")
+        if isinstance(value, int):
+            requested_cpus.append(value)
+
+    return {
+        "run": run_meta,
+        "counts": {
+            "task_events": len(tasks),
+            "resource_events": len(resources),
+            "worker_events": len(workers),
+            "failure_events": len(failures),
+            "cache_events": len(caches),
+            "artifact_events": len(artifacts),
+            "tasks_succeeded": state_counter.get("succeeded", 0),
+            "tasks_failed": state_counter.get("failed", 0),
+            "tasks_cancelled": state_counter.get("cancelled", 0),
+        },
+        "timing": {
+            "task_duration_count": len(duration_values),
+            "task_duration_total_s": round(sum(duration_values), 6),
+            "task_duration_avg_s": round(sum(duration_values) / len(duration_values), 6)
+            if duration_values
+            else None,
+        },
+        "cache": {
+            "hits": cache_hits,
+            "misses": cache_misses,
+            "hit_ratio": round(cache_hits / (cache_hits + cache_misses), 6)
+            if (cache_hits + cache_misses) > 0
+            else None,
+        },
+        "resources": {
+            "requested_cpu_min": min(requested_cpus) if requested_cpus else None,
+            "requested_cpu_max": max(requested_cpus) if requested_cpus else None,
+            "requested_cpu_avg": round(sum(requested_cpus) / len(requested_cpus), 6)
+            if requested_cpus
+            else None,
+        },
+        "failures": {
+            "classes": dict(sorted(failure_counter.items())),
+        },
+    }
+
+
+def render_text_report(summary: dict[str, Any]) -> str:
+    """Render a concise human-readable report."""
+    run = summary.get("run", {})
+    counts = summary.get("counts", {})
+    timing = summary.get("timing", {})
+    cache = summary.get("cache", {})
+
+    lines = [
+        f"run_id: {run.get('run_id', 'unknown')}",
+        f"project: {run.get('project_name', 'unknown')}",
+        f"target/provider: {run.get('target_name', 'unknown')}/{run.get('provider_name', 'unknown')}",
+        f"status: {run.get('status', 'unknown')}",
+        "",
+        "tasks:",
+        f"  succeeded: {counts.get('tasks_succeeded', 0)}",
+        f"  failed: {counts.get('tasks_failed', 0)}",
+        f"  cancelled: {counts.get('tasks_cancelled', 0)}",
+        f"  event_rows: {counts.get('task_events', 0)}",
+        "",
+        "timing:",
+        f"  total_s: {timing.get('task_duration_total_s')}",
+        f"  avg_s: {timing.get('task_duration_avg_s')}",
+        "",
+        "cache:",
+        f"  hits: {cache.get('hits', 0)}",
+        f"  misses: {cache.get('misses', 0)}",
+        f"  hit_ratio: {cache.get('hit_ratio')}",
+    ]
+    return "\n".join(lines)
+
+
+__all__ = [
+    "iter_run_dirs",
+    "latest_run_dir",
+    "read_jsonl",
+    "render_text_report",
+    "resolve_run_dir",
+    "summarize_run",
+]
+

--- a/scalable/telemetry/events.py
+++ b/scalable/telemetry/events.py
@@ -1,0 +1,169 @@
+"""Typed telemetry event schema records for Phase 2."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from datetime import UTC, datetime
+from typing import Any
+
+SCHEMA_VERSION: int = 1
+
+
+def utcnow_iso() -> str:
+    """Return a UTC timestamp in stable ISO-8601 form."""
+    return datetime.now(tz=UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+@dataclass(frozen=True)
+class RunMetadata:
+    """Top-level run metadata persisted to ``run.json``."""
+
+    run_id: str
+    project_name: str
+    target_name: str
+    provider_name: str
+    manifest_lock: str
+    source_manifest_path: str | None
+    started_at: str = field(default_factory=utcnow_iso)
+    finished_at: str | None = None
+    status: str = "running"
+    schema_version: int = SCHEMA_VERSION
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class TaskEvent:
+    """Task lifecycle event record."""
+
+    run_id: str
+    task_id: str
+    task_name: str
+    component: str | None
+    tag: str | None
+    state: str
+    function_name: str
+    requested_workers: int
+    timestamp: str = field(default_factory=utcnow_iso)
+    duration_s: float | None = None
+    worker: str | None = None
+    error_type: str | None = None
+    error_message: str | None = None
+    event_type: str = "task"
+    schema_version: int = SCHEMA_VERSION
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class ResourceEvent:
+    """Resource request/observation event record."""
+
+    run_id: str
+    entity_type: str
+    entity_id: str
+    component: str | None
+    provider: str
+    timestamp: str = field(default_factory=utcnow_iso)
+    requested_cpus: int | None = None
+    requested_memory: str | None = None
+    requested_walltime: str | None = None
+    requested_workers: int | None = None
+    observed_cpu: float | None = None
+    observed_memory_gb: float | None = None
+    event_type: str = "resource"
+    schema_version: int = SCHEMA_VERSION
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class WorkerEvent:
+    """Worker/cluster lifecycle event record."""
+
+    run_id: str
+    provider: str
+    state: str
+    timestamp: str = field(default_factory=utcnow_iso)
+    worker_id: str | None = None
+    component: str | None = None
+    details: dict[str, Any] = field(default_factory=dict)
+    event_type: str = "worker"
+    schema_version: int = SCHEMA_VERSION
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class FailureEvent:
+    """Failure classification event record."""
+
+    run_id: str
+    failure_class: str
+    message: str
+    timestamp: str = field(default_factory=utcnow_iso)
+    provider: str | None = None
+    task_id: str | None = None
+    details: dict[str, Any] = field(default_factory=dict)
+    event_type: str = "failure"
+    schema_version: int = SCHEMA_VERSION
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class CacheEvent:
+    """Cache hit/miss event record."""
+
+    run_id: str
+    function_name: str
+    key_digest: str
+    hit: bool
+    timestamp: str = field(default_factory=utcnow_iso)
+    duration_s: float | None = None
+    task_name: str | None = None
+    component: str | None = None
+    tag: str | None = None
+    event_type: str = "cache"
+    schema_version: int = SCHEMA_VERSION
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class ArtifactEvent:
+    """Artifact metadata event record."""
+
+    run_id: str
+    task_name: str
+    component: str | None
+    artifact_name: str
+    location: str
+    timestamp: str = field(default_factory=utcnow_iso)
+    kind: str | None = None
+    size_bytes: int | None = None
+    digest: str | None = None
+    event_type: str = "artifact"
+    schema_version: int = SCHEMA_VERSION
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+__all__ = [
+    "ArtifactEvent",
+    "CacheEvent",
+    "FailureEvent",
+    "ResourceEvent",
+    "RunMetadata",
+    "SCHEMA_VERSION",
+    "TaskEvent",
+    "WorkerEvent",
+    "utcnow_iso",
+]

--- a/scalable/telemetry/runtime.py
+++ b/scalable/telemetry/runtime.py
@@ -1,0 +1,112 @@
+"""Runtime telemetry context plumbing for session, client, and caching hooks."""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from contextvars import ContextVar, Token
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from .store import TelemetryStore
+
+
+_ACTIVE_STORE: ContextVar[TelemetryStore | None] = ContextVar(
+    "scalable_active_telemetry_store", default=None
+)
+_TASK_CONTEXT: ContextVar[dict[str, str | None] | None] = ContextVar(
+    "scalable_task_context", default=None
+)
+_GLOBAL_ACTIVE_STORE: TelemetryStore | None = None
+
+
+def set_active_store(store: TelemetryStore | None) -> Token[TelemetryStore | None]:
+    """Set process-local active telemetry store and return its token."""
+    global _GLOBAL_ACTIVE_STORE
+    _GLOBAL_ACTIVE_STORE = store
+    return _ACTIVE_STORE.set(store)
+
+
+def reset_active_store(token: Token[TelemetryStore | None]) -> None:
+    """Reset active telemetry store to previous value."""
+    global _GLOBAL_ACTIVE_STORE
+    _ACTIVE_STORE.reset(token)
+    _GLOBAL_ACTIVE_STORE = _ACTIVE_STORE.get()
+
+
+def get_active_store() -> TelemetryStore | None:
+    """Return the currently active telemetry store, if any."""
+    scoped = _ACTIVE_STORE.get()
+    if scoped is not None:
+        return scoped
+    return _GLOBAL_ACTIVE_STORE
+
+
+@contextmanager
+def task_context(
+    *,
+    task_name: str | None,
+    component: str | None,
+    tag: str | None,
+):
+    """Temporarily bind task execution context for cache and artifact hooks."""
+    token = _TASK_CONTEXT.set(
+        {
+            "task_name": task_name,
+            "component": component,
+            "tag": tag,
+        }
+    )
+    try:
+        yield
+    finally:
+        _TASK_CONTEXT.reset(token)
+
+
+def get_task_context() -> dict[str, str | None] | None:
+    """Get active task context for the current execution context."""
+    value = _TASK_CONTEXT.get()
+    if value is None:
+        return None
+    return dict(value)
+
+
+def emit_cache_event(*, function_name: str, key_digest: str, hit: bool, duration_s: float) -> None:
+    """Record a cache event through the active telemetry store, if configured."""
+    store = get_active_store()
+    if store is None:
+        return
+
+    context = get_task_context() or {}
+    store.record_cache_event(
+        function_name=function_name,
+        key_digest=key_digest,
+        hit=hit,
+        duration_s=duration_s,
+        task_name=context.get("task_name"),
+        component=context.get("component"),
+        tag=context.get("tag"),
+    )
+
+
+def emit_worker_event(*, provider: str, state: str, component: str | None = None, details: dict[str, Any] | None = None) -> None:
+    """Record provider worker/cluster events via the active telemetry store."""
+    store = get_active_store()
+    if store is None:
+        return
+    store.record_worker_event(
+        provider=provider,
+        state=state,
+        component=component,
+        details=details or {},
+    )
+
+
+__all__ = [
+    "emit_cache_event",
+    "emit_worker_event",
+    "get_active_store",
+    "get_task_context",
+    "reset_active_store",
+    "set_active_store",
+    "task_context",
+]

--- a/scalable/telemetry/store.py
+++ b/scalable/telemetry/store.py
@@ -1,0 +1,396 @@
+"""Run-scoped telemetry persistence primitives."""
+
+from __future__ import annotations
+
+import json
+import re
+import threading
+import time
+import uuid
+from dataclasses import replace
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+import yaml
+
+from scalable.manifest.schema import ManifestModel
+from scalable.planning.dryrun import DryRunPlan
+from scalable.providers.base import DeploymentSpec
+
+from .collectors import summarize_run
+from .events import (
+    ArtifactEvent,
+    CacheEvent,
+    FailureEvent,
+    ResourceEvent,
+    RunMetadata,
+    TaskEvent,
+    WorkerEvent,
+    utcnow_iso,
+)
+
+_PROJECT_RE = re.compile(r"[^a-zA-Z0-9._-]+")
+
+
+def build_run_id(project_name: str) -> str:
+    """Build a deterministic-format run id with UTC timestamp and random suffix."""
+    stamp = utcnow_iso().replace("-", "").replace(":", "")
+    stamp = stamp.replace("T", "T").replace("Z", "Z")
+    safe_project = _PROJECT_RE.sub("-", project_name).strip("-") or "project"
+    short = uuid.uuid4().hex[:8]
+    return f"run-{stamp}-{safe_project}-{short}"
+
+
+class TelemetryStore:
+    """Persist run telemetry as JSONL records under one run directory."""
+
+    _TASKS_FILE = "tasks.jsonl"
+    _RESOURCES_FILE = "resources.jsonl"
+    _WORKERS_FILE = "workers.jsonl"
+    _FAILURES_FILE = "failures.jsonl"
+    _CACHE_FILE = "cache.jsonl"
+    _ARTIFACTS_FILE = "artifacts.jsonl"
+
+    def __init__(
+        self,
+        *,
+        run_dir: Path,
+        metadata: RunMetadata,
+        component_defaults: dict[str, dict[str, Any]],
+        provider_name: str,
+        target_walltime: str | None,
+        telemetry_parquet: bool,
+    ) -> None:
+        self.run_dir = run_dir
+        self.metadata = metadata
+        self.component_defaults = component_defaults
+        self.provider_name = provider_name
+        self.target_walltime = target_walltime
+        self.telemetry_parquet = telemetry_parquet
+
+        self._lock = threading.RLock()
+        self._closed = False
+        self._task_started_at: dict[str, float] = {}
+
+    @property
+    def run_id(self) -> str:
+        return self.metadata.run_id
+
+    @classmethod
+    def create(
+        cls,
+        *,
+        runs_dir: str | Path,
+        manifest: ManifestModel,
+        spec: DeploymentSpec,
+        plan: DryRunPlan,
+        telemetry_parquet: bool = False,
+    ) -> TelemetryStore:
+        """Create run directory and initialize baseline run metadata files."""
+        runs_root = Path(runs_dir)
+        runs_root.mkdir(parents=True, exist_ok=True)
+
+        run_id = build_run_id(manifest.project.name)
+        run_dir = runs_root / run_id
+        run_dir.mkdir(parents=True, exist_ok=False)
+
+        metadata = RunMetadata(
+            run_id=run_id,
+            project_name=manifest.project.name,
+            target_name=spec.target_name,
+            provider_name=spec.provider_name,
+            manifest_lock=plan.manifest_lock,
+            source_manifest_path=manifest.source_path,
+        )
+
+        component_defaults: dict[str, dict[str, Any]] = {}
+        for cname, c in spec.components.items():
+            component_defaults[cname] = {
+                "cpus": c.cpus,
+                "memory": c.memory,
+            }
+
+        walltime = spec.target.options.get("walltime")
+        target_walltime = walltime if isinstance(walltime, str) else None
+
+        store = cls(
+            run_dir=run_dir,
+            metadata=metadata,
+            component_defaults=component_defaults,
+            provider_name=spec.provider_name,
+            target_walltime=target_walltime,
+            telemetry_parquet=telemetry_parquet,
+        )
+        store._write_bootstrap_files(manifest=manifest, plan=plan)
+        return store
+
+    def _write_bootstrap_files(self, *, manifest: ManifestModel, plan: DryRunPlan) -> None:
+        (self.run_dir / "manifest.yaml").write_text(
+            yaml.safe_dump(manifest.raw, sort_keys=True),
+            encoding="utf-8",
+        )
+        (self.run_dir / "plan.json").write_text(
+            json.dumps(plan.to_dict(), indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        (self.run_dir / "manifest.lock").write_text(plan.manifest_lock + "\n", encoding="utf-8")
+        (self.run_dir / "run.json").write_text(
+            json.dumps(self.metadata.to_dict(), indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+
+    def _append_jsonl(self, filename: str, payload: dict[str, Any]) -> None:
+        text = json.dumps(payload, sort_keys=True)
+        with self._lock:
+            with (self.run_dir / filename).open("a", encoding="utf-8") as fh:
+                fh.write(text + "\n")
+
+    def record_task_submission(
+        self,
+        *,
+        task_id: str,
+        task_name: str,
+        component: str | None,
+        tag: str | None,
+        function_name: str,
+        requested_workers: int,
+    ) -> None:
+        """Record a task submission and a synthetic running transition."""
+        self._task_started_at[task_id] = time.monotonic()
+
+        self._append_jsonl(
+            self._TASKS_FILE,
+            TaskEvent(
+                run_id=self.run_id,
+                task_id=task_id,
+                task_name=task_name,
+                component=component,
+                tag=tag,
+                state="submitted",
+                function_name=function_name,
+                requested_workers=requested_workers,
+            ).to_dict(),
+        )
+        self._append_jsonl(
+            self._TASKS_FILE,
+            TaskEvent(
+                run_id=self.run_id,
+                task_id=task_id,
+                task_name=task_name,
+                component=component,
+                tag=tag,
+                state="running",
+                function_name=function_name,
+                requested_workers=requested_workers,
+            ).to_dict(),
+        )
+
+        default_cpus = None
+        default_memory = None
+        if component and component in self.component_defaults:
+            default_cpus = self.component_defaults[component].get("cpus")
+            default_memory = self.component_defaults[component].get("memory")
+
+        self._append_jsonl(
+            self._RESOURCES_FILE,
+            ResourceEvent(
+                run_id=self.run_id,
+                entity_type="task",
+                entity_id=task_id,
+                component=component,
+                provider=self.provider_name,
+                requested_cpus=default_cpus if isinstance(default_cpus, int) else None,
+                requested_memory=default_memory if isinstance(default_memory, str) else None,
+                requested_walltime=self.target_walltime,
+                requested_workers=requested_workers,
+            ).to_dict(),
+        )
+
+    def record_task_result(
+        self,
+        *,
+        task_id: str,
+        task_name: str,
+        component: str | None,
+        tag: str | None,
+        function_name: str,
+        requested_workers: int,
+        state: str,
+        worker: str | None = None,
+        error_type: str | None = None,
+        error_message: str | None = None,
+    ) -> None:
+        """Record terminal task state and optional failure event."""
+        start = self._task_started_at.pop(task_id, None)
+        duration = None
+        if start is not None:
+            duration = max(time.monotonic() - start, 0.0)
+
+        self._append_jsonl(
+            self._TASKS_FILE,
+            TaskEvent(
+                run_id=self.run_id,
+                task_id=task_id,
+                task_name=task_name,
+                component=component,
+                tag=tag,
+                state=state,
+                function_name=function_name,
+                requested_workers=requested_workers,
+                duration_s=duration,
+                worker=worker,
+                error_type=error_type,
+                error_message=error_message,
+            ).to_dict(),
+        )
+
+        if state == "failed":
+            self._append_jsonl(
+                self._FAILURES_FILE,
+                FailureEvent(
+                    run_id=self.run_id,
+                    failure_class=error_type or "TaskError",
+                    message=error_message or "task failed",
+                    provider=self.provider_name,
+                    task_id=task_id,
+                ).to_dict(),
+            )
+
+    def record_cache_event(
+        self,
+        *,
+        function_name: str,
+        key_digest: str,
+        hit: bool,
+        duration_s: float,
+        task_name: str | None,
+        component: str | None,
+        tag: str | None,
+    ) -> None:
+        """Record one cache hit or miss event."""
+        self._append_jsonl(
+            self._CACHE_FILE,
+            CacheEvent(
+                run_id=self.run_id,
+                function_name=function_name,
+                key_digest=key_digest,
+                hit=hit,
+                duration_s=duration_s,
+                task_name=task_name,
+                component=component,
+                tag=tag,
+            ).to_dict(),
+        )
+
+    def record_worker_event(
+        self,
+        *,
+        provider: str,
+        state: str,
+        component: str | None,
+        details: dict[str, Any],
+    ) -> None:
+        """Record provider worker/cluster telemetry events."""
+        self._append_jsonl(
+            self._WORKERS_FILE,
+            WorkerEvent(
+                run_id=self.run_id,
+                provider=provider,
+                state=state,
+                component=component,
+                details=details,
+            ).to_dict(),
+        )
+
+    def record_failure(
+        self,
+        *,
+        failure_class: str,
+        message: str,
+        details: dict[str, Any] | None = None,
+        task_id: str | None = None,
+    ) -> None:
+        """Record a non-task-scoped failure."""
+        self._append_jsonl(
+            self._FAILURES_FILE,
+            FailureEvent(
+                run_id=self.run_id,
+                failure_class=failure_class,
+                message=message,
+                provider=self.provider_name,
+                task_id=task_id,
+                details=details or {},
+            ).to_dict(),
+        )
+
+    def record_artifact(
+        self,
+        *,
+        task_name: str,
+        component: str | None,
+        artifact_name: str,
+        location: str,
+        kind: str | None = None,
+        size_bytes: int | None = None,
+        digest: str | None = None,
+    ) -> None:
+        """Record artifact metadata emitted by a run."""
+        self._append_jsonl(
+            self._ARTIFACTS_FILE,
+            ArtifactEvent(
+                run_id=self.run_id,
+                task_name=task_name,
+                component=component,
+                artifact_name=artifact_name,
+                location=location,
+                kind=kind,
+                size_bytes=size_bytes,
+                digest=digest,
+            ).to_dict(),
+        )
+
+    def _write_summary(self) -> None:
+        summary = summarize_run(self.run_dir)
+        (self.run_dir / "summary.json").write_text(
+            json.dumps(summary, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+
+    def _write_parquet_snapshots(self) -> None:
+        if not self.telemetry_parquet:
+            return
+        snapshots = {
+            self._TASKS_FILE: "tasks.parquet",
+            self._RESOURCES_FILE: "resources.parquet",
+            self._WORKERS_FILE: "workers.parquet",
+        }
+        for src_name, dst_name in snapshots.items():
+            src = self.run_dir / src_name
+            if not src.exists() or src.stat().st_size == 0:
+                continue
+            try:
+                df = pd.read_json(src, lines=True)
+                if not df.empty:
+                    df.to_parquet(self.run_dir / dst_name, index=False)
+            except (ImportError, ValueError):
+                # Parquet dependencies and row shape validation are optional.
+                continue
+
+    def close(self, *, status: str = "completed") -> None:
+        """Flush summary and finalize run metadata."""
+        with self._lock:
+            if self._closed:
+                return
+            self._closed = True
+
+            self.metadata = replace(self.metadata, status=status, finished_at=utcnow_iso())
+            (self.run_dir / "run.json").write_text(
+                json.dumps(self.metadata.to_dict(), indent=2, sort_keys=True) + "\n",
+                encoding="utf-8",
+            )
+            self._write_summary()
+            self._write_parquet_snapshots()
+
+
+__all__ = ["TelemetryStore", "build_run_id"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,6 +26,9 @@ def _isolate_scalable_env(tmp_path, monkeypatch):
     monkeypatch.delenv("SCALABLE_CACHE_DIR", raising=False)
     monkeypatch.delenv("SCALABLE_SEED", raising=False)
     monkeypatch.delenv("SCALABLE_LOG_LEVEL", raising=False)
+    monkeypatch.delenv("SCALABLE_RUNS_DIR", raising=False)
+    monkeypatch.delenv("SCALABLE_TELEMETRY", raising=False)
+    monkeypatch.delenv("SCALABLE_TELEMETRY_PARQUET", raising=False)
     monkeypatch.delenv("COMM_PORT", raising=False)
     yield
 

--- a/tests/integration/test_session_telemetry_local.py
+++ b/tests/integration/test_session_telemetry_local.py
@@ -1,0 +1,71 @@
+"""Integration coverage for Phase 2 session telemetry with LocalProvider."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from scalable.caching import cacheable
+from scalable.session.session import ScalableSession
+
+
+def _write_manifest(path: Path) -> None:
+    path.write_text(
+        """
+version: 1
+project:
+  name: demo
+targets:
+  local:
+    provider: local
+    max_workers: 1
+    threads_per_worker: 1
+    processes: false
+    containers: none
+components:
+  gcam:
+    cpus: 1
+    memory: 1G
+tasks:
+  run_gcam:
+    component: gcam
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+
+@cacheable
+def _cached_increment(value: int) -> int:
+    return value + 1
+
+
+def test_session_writes_run_telemetry_and_summary(tmp_path: Path) -> None:
+    manifest_path = tmp_path / "scalable.yaml"
+    _write_manifest(manifest_path)
+
+    session = ScalableSession.from_yaml(manifest_path, target="local")
+    client = session.start()
+    try:
+        assert client.submit(_cached_increment, 41, tag="gcam").result(timeout=10) == 42
+        assert client.submit(_cached_increment, 41, tag="gcam").result(timeout=10) == 42
+    finally:
+        session.close()
+
+    runs_root = tmp_path / ".scalable" / "runs"
+    run_dirs = sorted(p for p in runs_root.iterdir() if p.is_dir())
+    assert len(run_dirs) == 1
+
+    run_dir = run_dirs[0]
+    assert (run_dir / "manifest.yaml").exists()
+    assert (run_dir / "plan.json").exists()
+    assert (run_dir / "manifest.lock").exists()
+    assert (run_dir / "run.json").exists()
+    assert (run_dir / "tasks.jsonl").exists()
+    assert (run_dir / "summary.json").exists()
+
+    run_payload = json.loads((run_dir / "run.json").read_text(encoding="utf-8"))
+    assert run_payload["status"] == "completed"
+
+    summary_payload = json.loads((run_dir / "summary.json").read_text(encoding="utf-8"))
+    assert summary_payload["counts"]["task_events"] >= 2
+

--- a/tests/unit/test_cli_report.py
+++ b/tests/unit/test_cli_report.py
@@ -1,0 +1,94 @@
+"""Unit tests for ``scalable report`` CLI behavior."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from scalable.cli.main import main
+
+
+def _seed_run(run_dir: Path) -> None:
+    run_dir.mkdir(parents=True, exist_ok=True)
+    (run_dir / "run.json").write_text(
+        json.dumps(
+            {
+                "run_id": run_dir.name,
+                "project_name": "demo",
+                "target_name": "local",
+                "provider_name": "local",
+                "status": "completed",
+            },
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (run_dir / "tasks.jsonl").write_text(
+        json.dumps(
+            {
+                "task_id": "t1",
+                "task_name": "run_gcam",
+                "component": "gcam",
+                "state": "succeeded",
+                "duration_s": 1.5,
+            },
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def test_cli_report_latest_text(tmp_path: Path, capsys) -> None:
+    runs_dir = tmp_path / "runs"
+    run_dir = runs_dir / "run-20260519T120000Z-demo-aaaa1111"
+    _seed_run(run_dir)
+
+    code = main(["report", "--runs-dir", str(runs_dir), "--latest"])
+
+    captured = capsys.readouterr()
+    assert code == 0
+    assert "run_id:" in captured.out
+    assert run_dir.name in captured.out
+
+
+def test_cli_report_json_and_output_file(tmp_path: Path, capsys) -> None:
+    runs_dir = tmp_path / "runs"
+    run_dir = runs_dir / "run-20260519T120000Z-demo-aaaa1111"
+    _seed_run(run_dir)
+    output = tmp_path / "report.json"
+
+    code = main(
+        [
+            "report",
+            "--runs-dir",
+            str(runs_dir),
+            "--run-id",
+            run_dir.name,
+            "--format",
+            "json",
+            "--output",
+            str(output),
+        ]
+    )
+
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    file_payload = json.loads(output.read_text(encoding="utf-8"))
+
+    assert code == 0
+    assert payload["run"]["run_id"] == run_dir.name
+    assert file_payload == payload
+
+
+def test_cli_report_missing_selection_returns_error(tmp_path: Path, capsys) -> None:
+    runs_dir = tmp_path / "runs"
+    runs_dir.mkdir(parents=True, exist_ok=True)
+
+    code = main(["report", "--runs-dir", str(runs_dir)])
+    captured = capsys.readouterr()
+
+    assert code == 1
+    assert "report failed" in captured.err
+

--- a/tests/unit/test_common_settings.py
+++ b/tests/unit/test_common_settings.py
@@ -25,6 +25,9 @@ def test_settings_defaults():
     assert s.seed == common.DEFAULT_SEED
     assert s.manifest_path == "./scalable.yaml"
     assert s.target is None
+    assert s.runs_dir == "./.scalable/runs"
+    assert s.telemetry_enabled is True
+    assert s.telemetry_parquet is False
 
 
 def test_settings_env_overrides(monkeypatch):
@@ -32,6 +35,9 @@ def test_settings_env_overrides(monkeypatch):
     monkeypatch.setenv("SCALABLE_SEED", "42")
     monkeypatch.setenv("SCALABLE_MANIFEST", "/tmp/scalable.yaml")
     monkeypatch.setenv("SCALABLE_TARGET", "local")
+    monkeypatch.setenv("SCALABLE_RUNS_DIR", "/tmp/scalable-runs")
+    monkeypatch.setenv("SCALABLE_TELEMETRY", "0")
+    monkeypatch.setenv("SCALABLE_TELEMETRY_PARQUET", "1")
 
     # Reload to pick up env vars in field defaults.
     from scalable import common as common_mod
@@ -41,6 +47,9 @@ def test_settings_env_overrides(monkeypatch):
     assert s.seed == 42
     assert s.manifest_path == "/tmp/scalable.yaml"
     assert s.target == "local"
+    assert s.runs_dir == "/tmp/scalable-runs"
+    assert s.telemetry_enabled is False
+    assert s.telemetry_parquet is True
 
 
 def test_legacy_module_aliases_match_singleton():

--- a/tests/unit/test_public_api_exports.py
+++ b/tests/unit/test_public_api_exports.py
@@ -12,6 +12,8 @@ def test_top_level_exports_include_session_and_provider_symbols() -> None:
     assert "DeploymentProvider" in exported
     assert "LocalProvider" in exported
     assert "SlurmProvider" in exported
+    assert "ResourceAdvisor" in exported
+    assert "ResourceRecommendation" in exported
 
 
 def test_legacy_exports_remain_available() -> None:
@@ -24,4 +26,3 @@ def test_legacy_exports_remain_available() -> None:
     assert "ScalableClient" in exported
     assert "SEED" in exported
     assert "settings" in exported
-

--- a/tests/unit/test_resource_advisor.py
+++ b/tests/unit/test_resource_advisor.py
@@ -1,0 +1,90 @@
+"""Unit tests for deterministic ResourceAdvisor recommendations."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from scalable.advising import ResourceAdvisor
+
+
+def _append_jsonl(path: Path, rows: list[dict]) -> None:
+    path.write_text("\n".join(json.dumps(r, sort_keys=True) for r in rows) + "\n", encoding="utf-8")
+
+
+def _seed_run(run_dir: Path, *, duration_s: float, cpus: int, memory: str, workers: int) -> None:
+    run_dir.mkdir(parents=True, exist_ok=True)
+    (run_dir / "run.json").write_text(
+        json.dumps(
+            {
+                "run_id": run_dir.name,
+                "target_name": "local",
+            },
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    _append_jsonl(
+        run_dir / "tasks.jsonl",
+        [
+            {
+                "task_id": "t1",
+                "task_name": "run_gcam",
+                "component": "gcam",
+                "state": "succeeded",
+                "duration_s": duration_s,
+            }
+        ],
+    )
+    _append_jsonl(
+        run_dir / "resources.jsonl",
+        [
+            {
+                "entity_type": "task",
+                "entity_id": "t1",
+                "requested_workers": workers,
+                "requested_cpus": cpus,
+                "requested_memory": memory,
+                "requested_walltime": "00:30:00",
+            }
+        ],
+    )
+
+
+def test_resource_advisor_returns_history_based_recommendation(tmp_path: Path) -> None:
+    runs = tmp_path / "runs"
+    _seed_run(
+        runs / "run-20260519T120000Z-demo-aaaa1111",
+        duration_s=120.0,
+        cpus=4,
+        memory="8G",
+        workers=1,
+    )
+    _seed_run(
+        runs / "run-20260519T130000Z-demo-bbbb2222",
+        duration_s=300.0,
+        cpus=6,
+        memory="16G",
+        workers=2,
+    )
+
+    advisor = ResourceAdvisor.from_history(runs)
+    recommendation = advisor.recommend(task="run_gcam", target="local", confidence=0.95)
+
+    assert recommendation.task == "run_gcam"
+    assert recommendation.target == "local"
+    assert "gcam" in recommendation.workers
+    assert recommendation.workers["gcam"] >= 1
+    assert recommendation.resources["gcam"]["cpus"] >= 1
+    assert recommendation.evidence["records"] >= 2
+
+
+def test_resource_advisor_handles_missing_history(tmp_path: Path) -> None:
+    advisor = ResourceAdvisor.from_history(tmp_path / "runs")
+    recommendation = advisor.recommend(task="missing_task", target="local")
+
+    assert recommendation.workers == {"missing_task": 1}
+    assert recommendation.resources["missing_task"]["cpus"] == 1
+    assert recommendation.evidence["records"] == 0
+

--- a/tests/unit/test_telemetry_collectors.py
+++ b/tests/unit/test_telemetry_collectors.py
@@ -1,0 +1,117 @@
+"""Unit tests for telemetry collectors and report rendering."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from scalable.telemetry.collectors import (
+    latest_run_dir,
+    read_jsonl,
+    render_text_report,
+    resolve_run_dir,
+    summarize_run,
+)
+
+
+def _write_jsonl(path: Path, rows: list[dict]) -> None:
+    payload = "\n".join(json.dumps(row, sort_keys=True) for row in rows) + "\n"
+    path.write_text(payload, encoding="utf-8")
+
+
+def _seed_run(run_dir: Path) -> None:
+    run_dir.mkdir(parents=True, exist_ok=True)
+    (run_dir / "run.json").write_text(
+        json.dumps(
+            {
+                "run_id": run_dir.name,
+                "project_name": "demo",
+                "target_name": "local",
+                "provider_name": "local",
+                "status": "completed",
+            },
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    _write_jsonl(
+        run_dir / "tasks.jsonl",
+        [
+            {
+                "task_id": "t1",
+                "task_name": "run_gcam",
+                "component": "gcam",
+                "state": "succeeded",
+                "duration_s": 3.5,
+            },
+            {
+                "task_id": "t2",
+                "task_name": "run_gcam",
+                "component": "gcam",
+                "state": "failed",
+                "duration_s": 1.0,
+            },
+        ],
+    )
+    _write_jsonl(
+        run_dir / "resources.jsonl",
+        [
+            {
+                "entity_type": "task",
+                "entity_id": "t1",
+                "requested_cpus": 4,
+            },
+            {
+                "entity_type": "task",
+                "entity_id": "t2",
+                "requested_cpus": 6,
+            },
+        ],
+    )
+    _write_jsonl(
+        run_dir / "cache.jsonl",
+        [
+            {"hit": False},
+            {"hit": True},
+        ],
+    )
+    _write_jsonl(
+        run_dir / "failures.jsonl",
+        [
+            {"failure_class": "RuntimeError"},
+            {"failure_class": "RuntimeError"},
+        ],
+    )
+
+
+def test_read_jsonl_missing_returns_empty(tmp_path: Path) -> None:
+    assert read_jsonl(tmp_path / "missing.jsonl") == []
+
+
+def test_summarize_run_and_render_text(tmp_path: Path) -> None:
+    run_dir = tmp_path / "run-20260519T120000Z-demo-aaaa1111"
+    _seed_run(run_dir)
+
+    summary = summarize_run(run_dir)
+    text = render_text_report(summary)
+
+    assert summary["counts"]["tasks_succeeded"] == 1
+    assert summary["counts"]["tasks_failed"] == 1
+    assert summary["cache"]["hits"] == 1
+    assert summary["cache"]["misses"] == 1
+    assert "run_id:" in text
+    assert "tasks:" in text
+
+
+def test_resolve_run_dir_latest_and_id(tmp_path: Path) -> None:
+    runs = tmp_path / "runs"
+    run1 = runs / "run-20260519T120000Z-demo-aaaa1111"
+    run2 = runs / "run-20260519T130000Z-demo-bbbb2222"
+    _seed_run(run1)
+    _seed_run(run2)
+
+    assert latest_run_dir(runs) == run2
+    assert resolve_run_dir(runs_dir=runs, latest=True) == run2
+    assert resolve_run_dir(runs_dir=runs, run_id=run1.name) == run1
+

--- a/tests/unit/test_telemetry_store.py
+++ b/tests/unit/test_telemetry_store.py
@@ -1,0 +1,89 @@
+"""Unit tests for TelemetryStore persistence primitives."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from scalable.manifest.parser import load_manifest
+from scalable.planning.dryrun import build_dry_run_plan
+from scalable.providers.base import DeploymentSpec
+from scalable.telemetry.store import TelemetryStore
+
+
+def _write_manifest(path: Path) -> None:
+    path.write_text(
+        """
+version: 1
+project:
+  name: demo
+targets:
+  local:
+    provider: local
+components:
+  gcam:
+    cpus: 2
+    memory: 8G
+tasks:
+  run_gcam:
+    component: gcam
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+
+def test_store_writes_bootstrap_and_summary(tmp_path: Path) -> None:
+    manifest_path = tmp_path / "scalable.yaml"
+    _write_manifest(manifest_path)
+
+    manifest = load_manifest(manifest_path)
+    spec = DeploymentSpec.from_manifest(manifest, target_name="local")
+    plan = build_dry_run_plan(spec)
+
+    store = TelemetryStore.create(
+        runs_dir=tmp_path / "runs",
+        manifest=manifest,
+        spec=spec,
+        plan=plan,
+    )
+
+    store.record_task_submission(
+        task_id="t1",
+        task_name="run_gcam",
+        component="gcam",
+        tag="gcam",
+        function_name="run_gcam",
+        requested_workers=1,
+    )
+    store.record_task_result(
+        task_id="t1",
+        task_name="run_gcam",
+        component="gcam",
+        tag="gcam",
+        function_name="run_gcam",
+        requested_workers=1,
+        state="succeeded",
+    )
+    store.record_cache_event(
+        function_name="run_gcam",
+        key_digest="123",
+        hit=False,
+        duration_s=0.1,
+        task_name="run_gcam",
+        component="gcam",
+        tag="gcam",
+    )
+    store.close(status="completed")
+
+    run_dir = store.run_dir
+    assert (run_dir / "manifest.yaml").exists()
+    assert (run_dir / "plan.json").exists()
+    assert (run_dir / "manifest.lock").exists()
+    assert (run_dir / "run.json").exists()
+    assert (run_dir / "summary.json").exists()
+
+    run_payload = json.loads((run_dir / "run.json").read_text(encoding="utf-8"))
+    summary = json.loads((run_dir / "summary.json").read_text(encoding="utf-8"))
+    assert run_payload["status"] == "completed"
+    assert summary["counts"]["task_events"] >= 3
+


### PR DESCRIPTION
## Phase 2: Telemetry and Deterministic Advising

Implements [`plans/v2.0.0_phase2_plan.md`](plans/v2.0.0_phase2_plan.md:1) on the dedicated feature branch `version/2.0.0-phase2-telemetry-advising` off of the long-lived integration branch `version/2.0.0`.

### Summary

Phase 2 introduces durable run telemetry, a manifest-linked run history store, deterministic resource advising, and the implemented `scalable report` CLI command. All Phase 1 contracts (`ScalableSession`, `DeploymentProvider`, manifest validation, dry-run planning, `manifest.lock`) are preserved and now anchored to deterministic per-run telemetry artifacts.

### Scope (as defined in the Phase 2 plan)

- Run history store
- Task/resource/failure event schema
- Artifact metadata
- Baseline `ResourceAdvisor`
- Cache hit/miss reports
- `scalable report`

### Implementation highlights

#### Telemetry package

New package [`scalable/telemetry/`](scalable/telemetry/__init__.py:1) with:

- [`events.py`](scalable/telemetry/events.py:1): versioned dataclasses for `RunMetadata`, `TaskEvent`, `ResourceEvent`, `WorkerEvent`, `FailureEvent`, `CacheEvent`, `ArtifactEvent` (`schema_version=1`).
- [`store.py`](scalable/telemetry/store.py:1): `TelemetryStore` persists each run under `.scalable/runs/<run-id>/` with canonical JSONL streams, persisted `manifest.yaml`, `plan.json`, `manifest.lock`, `run.json`, finalization summary, and optional parquet snapshots when an extra is installed.
- [`collectors.py`](scalable/telemetry/collectors.py:1): deterministic run loading, summary aggregation, `--latest` resolution, and text/JSON report rendering.
- [`runtime.py`](scalable/telemetry/runtime.py:1): contextvar-based active store and task context plumbing (with cross-process global fallback).

#### Session/client/provider/caching integration

- [`scalable/session/session.py`](scalable/session/session.py:1): creates the run telemetry store at session start, finalizes it at close, and exposes `record_artifact(...)` for runtime artifact metadata recording.
- [`scalable/client.py`](scalable/client.py:1): instruments `ScalableClient.submit` and `ScalableClient.map` to record submitted/running/succeeded/failed/cancelled task events through Dask future callbacks; binds task context for downstream cache events.
- [`scalable/caching.py`](scalable/caching.py:1): emits cache hit/miss events with timing information through the runtime hook.
- [`scalable/providers/local.py`](scalable/providers/local.py:1) and [`scalable/providers/slurm.py`](scalable/providers/slurm.py:1): emit cluster lifecycle and scaling worker events.

#### Deterministic advising API

- New [`scalable/advising/resources.py`](scalable/advising/resources.py:1) with `ResourceAdvisor.from_history(...)` and `recommend(...)` returning explainable `ResourceRecommendation` payloads using confidence-indexed quantiles plus safety margins, with sparse-history fallbacks.
- Top-level exports added in [`scalable/__init__.py`](scalable/__init__.py:1).

#### CLI: `scalable report`

- New handler in [`scalable/cli/cmd_report.py`](scalable/cli/cmd_report.py:1) replaces the Phase 1 stub.
- Supports `--runs-dir`, `--run-id`, `--latest`, `--format text|json`, `--output`.
- Wired into the dispatcher in [`scalable/cli/main.py`](scalable/cli/main.py:1) and the package CLI module docs in [`scalable/cli/__init__.py`](scalable/cli/__init__.py:1).

#### Configuration

New telemetry settings in [`scalable/common.py`](scalable/common.py:1) and tests in [`tests/unit/test_common_settings.py`](tests/unit/test_common_settings.py:1):

- `runs_dir` (`SCALABLE_RUNS_DIR`, default `./.scalable/runs`)
- `telemetry_enabled` (`SCALABLE_TELEMETRY`, default enabled for manifest-driven sessions)
- `telemetry_parquet` (`SCALABLE_TELEMETRY_PARQUET`, optional)

### Documentation

- New [`docs/telemetry.rst`](docs/telemetry.rst:1)
- New [`docs/advising.rst`](docs/advising.rst:1)
- Linked from [`docs/index.rst`](docs/index.rst:1) and [`docs/getting_started.rst`](docs/getting_started.rst:1)
- Phase 2 usage examples added to [`README.md`](README.md:1)

### Tests

- [`tests/unit/test_telemetry_collectors.py`](tests/unit/test_telemetry_collectors.py:1)
- [`tests/unit/test_telemetry_store.py`](tests/unit/test_telemetry_store.py:1)
- [`tests/unit/test_cli_report.py`](tests/unit/test_cli_report.py:1)
- [`tests/unit/test_resource_advisor.py`](tests/unit/test_resource_advisor.py:1)
- [`tests/integration/test_session_telemetry_local.py`](tests/integration/test_session_telemetry_local.py:1)
- Adjusted env isolation in [`tests/conftest.py`](tests/conftest.py:1) and updated [`tests/unit/test_common_settings.py`](tests/unit/test_common_settings.py:1) and [`tests/unit/test_public_api_exports.py`](tests/unit/test_public_api_exports.py:1).

### Files changed

**Created**
- `scalable/telemetry/__init__.py`
- `scalable/telemetry/events.py`
- `scalable/telemetry/store.py`
- `scalable/telemetry/collectors.py`
- `scalable/telemetry/runtime.py`
- `scalable/advising/__init__.py`
- `scalable/advising/resources.py`
- `scalable/cli/cmd_report.py`
- `docs/telemetry.rst`
- `docs/advising.rst`
- `tests/unit/test_telemetry_collectors.py`
- `tests/unit/test_telemetry_store.py`
- `tests/unit/test_cli_report.py`
- `tests/unit/test_resource_advisor.py`
- `tests/integration/test_session_telemetry_local.py`

**Modified**
- `scalable/__init__.py`
- `scalable/common.py`
- `scalable/caching.py`
- `scalable/client.py`
- `scalable/session/session.py`
- `scalable/providers/local.py`
- `scalable/providers/slurm.py`
- `scalable/cli/main.py`
- `scalable/cli/__init__.py`
- `tests/conftest.py`
- `tests/unit/test_common_settings.py`
- `tests/unit/test_public_api_exports.py`
- `README.md`
- `docs/index.rst`
- `docs/getting_started.rst`
- `CHANGELOG.md`

**Removed**
- None. Phase 2 is strictly additive.

### Validation

- `ruff check scalable tests` passes
- `pytest -q` passes: 166 tests, 0 failures (Phase 1 regression tests preserved + Phase 2 unit/integration suites added)

### Phase 2 success criteria checklist

- [x] Starting a session creates a unique run directory under `.scalable/runs/`
- [x] Each run directory contains `manifest.yaml`, `plan.json`, `manifest.lock`, and `run.json`
- [x] Task events captured for queued/running/succeeded/failed/cancelled with timestamps and run linkage
- [x] Resource events include requested CPU/memory/walltime and provider context
- [x] Cache hit/miss events persisted with task/function context
- [x] Failure events include classification, message, and provider context
- [x] Artifact metadata records persisted via session API
- [x] `ResourceAdvisor.from_history(...)` builds deterministic state
- [x] `ResourceAdvisor.recommend(...)` supports confidence-indexed quantile recommendations with safety margins
- [x] `scalable report` implemented with text and JSON outputs
- [x] Unit + integration tests for telemetry, report, and advisor
- [x] Documentation and changelog updates

### Cross-phase groundwork enabled

| Artifact | Consumer |
|----------|----------|
| Stable event schemas with `schema_version` | Phase 4 diagnosis, Phase 5 ML |
| Run store with manifest linkage | Phase 4 explain, migration assistant |
| `ResourceAdvisor` API | Phase 5 learned advisor (drop-in implementation) |
| Cache event metrics | Phase 3 remote cache, Phase 5 cache policy learning |
| `scalable report` JSON envelope | Phase 4 assistant-readable diagnostics |

### Out of scope (per Phase 2 plan)

- No Kubernetes/cloud providers (Phase 3)
- No LLM-driven planning/diagnosis (Phase 4)
- No learned predictive models or emulators (Phase 5)
- No replacement of legacy imperative API paths

### Branching and workflow

- Source branch: `version/2.0.0-phase2-telemetry-advising`
- Target branch: `version/2.0.0`
- Phase 3 will branch off `version/2.0.0` after this PR is merged
- `version/2.0.0` will not be merged to `master` until all phases land