### PR TITLE
Version/2.0.0 phase5 ml emulation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,71 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.0a5] — Phase 5: ML Optimization and Emulation
+
+### Added
+
+- **ML optimization subsystem** (`scalable.ml`) with learned resource prediction
+  and adaptive scaling:
+  - `LearnedAdvisor` — ML-backed resource recommendations using gradient
+    boosting, random forest, or quantile regression trained on telemetry history
+  - `AdaptiveScaler` — real-time adaptive worker scaling with configurable
+    thresholds, min/max bounds, and cooldown periods
+  - `FeatureExtractor` — telemetry feature engineering with rolling aggregates,
+    task identity hashing, and user-provided input features
+  - `ResourceModel` — unified sklearn model wrapper with fit/predict/intervals,
+    model serialization, and percentile fallback when sklearn unavailable
+  - `HyperparameterSearch` — Dask-ML distributed tuning integration
+    (hyperband, successive halving, random) with sklearn fallback
+  - `cross_validate_advisor` — model quality assessment framework
+- **Model emulation subsystem** (`scalable.emulation`) with uncertainty-aware
+  surrogate model dispatch:
+  - `@emulatable` decorator marking functions as emulation-capable with
+    declared inputs, outputs, domain bounds, and confidence thresholds
+  - `EmulatorRegistry` — versioned emulator management with filesystem
+    persistence, domain validation, and joblib serialization
+  - `EmulatorDispatch` — confidence-gated routing between emulator and
+    full model with provenance recording
+  - `ActiveLearner` — intelligent scenario selection using expected
+    improvement, maximum uncertainty, or random acquisition strategies
+  - `GradientBoostingEmulator` and `RandomForestEmulator` surrogate
+    model implementations with tree-based uncertainty estimation
+  - `calibrate_emulator` — uncertainty calibration assessment with
+    coverage and sharpness metrics
+- **`scalable advise` CLI command** for ML-backed resource recommendations:
+  - Supports `--task`, `--target`, `--model-type`, `--confidence`, `--format`
+  - Graceful degradation to Phase 2 heuristic advisor when ML unavailable
+  - Text and JSON output formats
+- **`EmulationEvent` telemetry** for tracking emulator dispatch decisions
+  including source, confidence, fallback reason, and domain validity.
+- **Settings extensions** (`scalable.common.Settings`):
+  - `ml_model_cache_dir` (`SCALABLE_ML_CACHE_DIR`)
+  - `emulator_registry_dir` (`SCALABLE_EMULATOR_DIR`)
+  - `ml_enabled` (`SCALABLE_ML`)
+  - `emulation_enabled` (`SCALABLE_EMULATION`)
+  - `emulation_confidence_threshold` (`SCALABLE_EMULATION_CONFIDENCE`)
+- **`[project.optional-dependencies] ml`** extra with `scikit-learn >= 1.3`,
+  `dask-ml >= 2023.3.24`, and `joblib >= 1.3`.
+- **Public API**: `LearnedAdvisor`, `AdaptiveScaler`, `HyperparameterSearch`,
+  `EmulatorRegistry`, `EmulatorDispatch`, `ActiveLearner`, `emulatable`
+  exported from `scalable.__init__` with optional-dep guards.
+
+### Changed
+
+- Bumped version to `2.0.0a5`.
+- CLI main dispatcher now supports both `handler` and `func` argument
+  patterns for command registration.
+- `scalable advise` added as implemented CLI command.
+
+### Tests
+
+- 75 new unit tests for ML features, models, adaptive scaler, emulation
+  decorator, registry, dispatch, uncertainty calibration, active learning,
+  telemetry events, settings, and CLI.
+- 431 total unit tests passing (no regressions from Phases 1–4).
+
+---
+
 ## [2.0.0a4] — Phase 4: AI Assistant Features
 
 ### Added

--- a/plans/v2.0.0_phase5_plan.md
+++ b/plans/v2.0.0_phase5_plan.md
@@ -1,0 +1,904 @@
+# Scalable v2.0.0 — Phase 5 Implementation Plan
+
+> **Phase 5: ML Optimization and Emulation**
+> Source plan: [`plans/v2.0.0_development_phases.md`](plans/v2.0.0_development_phases.md)
+> Prior merged phases: Phase 1 (PR #20), Phase 2 (PR #21), Phase 3 (PR #22), Phase 4 (PR #23)
+> Integration branch: `version/2.0.0`
+> Phase 5 feature branch: `version/2.0.0-phase5-ml-emulation` (off `version/2.0.0`)
+
+---
+
+## 1. Cross-phase context and dependency analysis
+
+### 1.1 What Phases 1–4 established
+
+Phase 5 is the capstone phase, consuming the full infrastructure delivered across the prior four phases:
+
+| Phase | Key artifacts consumed by Phase 5 |
+|-------|-----------------------------------|
+| **Phase 1** | `DeploymentProvider` protocol, `ScalePlan`, `ResourceRequest`, `ScalableSession.plan(objective=, policy=)` reserved kwargs, provider registry, manifest schema |
+| **Phase 2** | Telemetry run store (`.scalable/runs/`), `TaskEvent`/`ResourceEvent`/`FailureEvent` schemas, `ResourceAdvisor` with quantile heuristics, `ResourceRecommendation` payload |
+| **Phase 3** | `CostEstimate`, cost telemetry (`cost.jsonl`), `ArtifactStore` protocol, remote cache backend, overlay system |
+| **Phase 4** | `AIBackend` protocol, failure taxonomy in `log_diagnosis.py`, heuristic `_apply_objective_policy`, `ScalableSession.plan(objective=, policy=)` heuristic implementation, prompt template system |
+
+### 1.2 What Phase 5 delivers (final phase)
+
+Phase 5 is the terminal phase of the v2.0.0 roadmap. It replaces heuristic systems with learned ones and adds scientific model emulation as a first-class capability:
+
+1. **Learned resource prediction** — replaces quantile heuristics with feature-based ML models
+2. **Adaptive scaling policy** — real-time scaling decisions informed by ML predictions
+3. **Active-learning scenario selection** — intelligent selection of which full-model runs maximize information gain
+4. **Emulator registry** — declarative registration and lifecycle management of surrogate models
+5. **Uncertainty-aware full-model fallback** — confidence-gated emulator usage with automatic fallback
+6. **Distributed hyperparameter tuning** — Dask-ML integration for efficient model selection
+
+### 1.3 Design principles
+
+From the master plan's design principles:
+
+- **AI proposes; Scalable disposes.** ML models produce predictions and recommendations that are validated by deterministic policy before execution.
+- **Every plan is inspectable.** ML-based plans include feature importances, confidence intervals, and training provenance.
+- **Manual overrides always win.** Users can pin resources, ignore ML recommendations, or disable emulators entirely.
+- **Emulators are opt-in and uncertainty-aware.** They accelerate exploration but never silently replace validated model runs.
+- **Offline-compatible by default.** ML models are trained/cached locally; no remote inference required.
+
+### 1.4 Phase 5 out-of-scope boundaries
+
+- No new deployment providers (Phase 3 delivered the full provider set)
+- No new CLI commands beyond `scalable advise` (existing `scalable report` and `scalable explain` are extended)
+- No breaking changes to Phase 1–4 APIs
+- No mandatory external ML service dependencies
+
+---
+
+## 2. Phase 5 scope, objectives, and success criteria
+
+### 2.1 Scope (from master plan §Phase 5)
+
+Deliverables:
+- Learned resource prediction
+- Adaptive scaling policy
+- Active-learning scenario selection
+- Emulator registry
+- Uncertainty-aware full-model fallback
+- Distributed hyperparameter tuning
+
+### 2.2 Objectives
+
+1. **Replace heuristic `ResourceAdvisor.recommend()` with ML-backed predictions** that use task features (input size, scenario count, component version, etc.) to predict runtime, memory, and cost with calibrated uncertainty.
+2. **Implement adaptive scaling policies** that adjust worker counts in real-time based on task queue depth, predicted completion times, and resource utilization.
+3. **Add an active-learning framework** for scientific ensemble workflows that selects the next most informative full-model runs to maximize emulator training efficiency.
+4. **Introduce an emulator registry** where trained surrogate models are declared, versioned, and bound to components with clear domain boundaries.
+5. **Implement uncertainty-aware emulator dispatch** with automatic full-model fallback when emulator confidence is below threshold.
+6. **Integrate Dask-ML for distributed hyperparameter tuning** across the cluster for emulator training and resource model fitting.
+
+### 2.3 Success criteria
+
+- [ ] `LearnedAdvisor.from_history(path)` trains a resource prediction model from telemetry and produces recommendations with calibrated confidence intervals.
+- [ ] `LearnedAdvisor.recommend(task, input_features, ...)` returns predictions that outperform quantile heuristics on held-out telemetry data (measurable via cross-validation).
+- [ ] `AdaptiveScaler` monitors task queue and adjusts worker counts according to a learned or rule-based policy, respecting user-defined bounds.
+- [ ] `@scalable.emulatable(...)` decorator registers a function as emulation-capable with declared inputs, outputs, uncertainty requirements, and fallback behavior.
+- [ ] `EmulatorRegistry` manages trained emulators with versioning, domain validation, and confidence thresholds.
+- [ ] Emulator dispatch transparently serves predictions when confidence is high and falls back to the full model otherwise, recording which path was used.
+- [ ] `ActiveLearner` selects next-best scenarios from a candidate pool by maximizing expected information gain for emulator training.
+- [ ] `HyperparameterSearch` wraps Dask-ML search strategies for distributed model tuning within a session.
+- [ ] `scalable advise` CLI command provides ML-backed resource recommendations.
+- [ ] All ML features degrade gracefully to Phase 2/4 heuristics when training data is insufficient or `scalable[ml]` is not installed.
+- [ ] Unit tests cover all new modules; integration test demonstrates emulator train/predict/fallback cycle.
+- [ ] `CHANGELOG.md` updated for `2.0.0a5`.
+
+---
+
+## 3. Technical architecture
+
+### 3.1 New package layout
+
+```
+scalable/
+  ml/                                # NEW — ML optimization subsystem
+    __init__.py                      # public exports
+    learned_advisor.py               # ML-based resource prediction (replaces heuristic)
+    adaptive_scaler.py               # Real-time adaptive scaling policy
+    features.py                      # Feature extraction from telemetry + task args
+    models.py                        # Model wrappers (sklearn, gradient boosting)
+    validation.py                    # Cross-validation and model quality checks
+    tuning.py                        # Dask-ML hyperparameter search integration
+
+  emulation/                         # NEW — Model emulation subsystem
+    __init__.py                      # public exports
+    registry.py                      # EmulatorRegistry for trained surrogates
+    decorator.py                     # @emulatable decorator
+    dispatch.py                      # Uncertainty-aware routing (emulator vs full model)
+    active_learning.py               # Active scenario selection
+    surrogate.py                     # Surrogate model abstractions (GP, RF, NN)
+    uncertainty.py                   # Calibration and confidence estimation
+
+  cli/
+    cmd_advise.py                    # NEW — ML-backed resource advice CLI
+
+  advising/
+    resources.py                     # MODIFIED — add LearnedAdvisor integration hook
+```
+
+### 3.2 Learned resource advisor (`ml/learned_advisor.py`)
+
+```python
+class LearnedAdvisor:
+    """ML-backed resource advisor using telemetry history as training data."""
+
+    @classmethod
+    def from_history(
+        cls,
+        runs_dir: str | Path,
+        *,
+        model_type: str = "gradient_boosting",  # or "quantile_regression", "random_forest"
+        retrain: bool = False,
+        cache_dir: str | Path | None = None,
+    ) -> LearnedAdvisor: ...
+
+    def recommend(
+        self,
+        *,
+        task: str,
+        input_features: dict[str, Any] | None = None,
+        target: str | None = None,
+        confidence: float = 0.95,
+    ) -> ResourceRecommendation: ...
+
+    def explain(self, recommendation: ResourceRecommendation) -> dict[str, Any]:
+        """Return feature importances and prediction intervals."""
+        ...
+
+    def evaluate(self, *, test_fraction: float = 0.2) -> ModelQuality:
+        """Cross-validate the model and return quality metrics."""
+        ...
+```
+
+The `LearnedAdvisor` shares the same `ResourceRecommendation` return type as the Phase 2 `ResourceAdvisor`, ensuring backward compatibility. It adds:
+- Feature extraction from task arguments (input size, scenario count, spatial resolution)
+- Calibrated prediction intervals (not just point estimates)
+- Feature importance explanations
+- Model quality self-assessment
+
+Model selection strategy:
+1. **Gradient boosting (default)** — robust for tabular telemetry features
+2. **Quantile regression** — for uncertainty-calibrated interval predictions
+3. **Random forest** — interpretable alternative
+4. **Survival models** — for queue wait and walltime prediction (stretch goal)
+
+### 3.3 Feature extraction (`ml/features.py`)
+
+```python
+class FeatureExtractor:
+    """Extract ML features from telemetry records and task arguments."""
+
+    def extract_from_history(self, records: pd.DataFrame) -> pd.DataFrame:
+        """Engineer features from historical telemetry records."""
+        ...
+
+    def extract_from_task(
+        self,
+        task_name: str,
+        input_features: dict[str, Any] | None,
+        component: str | None,
+        target: str | None,
+    ) -> pd.DataFrame:
+        """Build feature vector for a new prediction request."""
+        ...
+```
+
+Engineered features:
+- Task identity features (component name, tag hash)
+- Resource request features (requested cpus/memory/walltime)
+- Temporal features (time of day, day of week for queue prediction)
+- Input complexity features (from `input_features` dict)
+- Historical aggregates (rolling mean/p95 for same task)
+- Provider/target features (one-hot encoded)
+
+### 3.4 Adaptive scaling policy (`ml/adaptive_scaler.py`)
+
+```python
+class AdaptiveScaler:
+    """Real-time adaptive worker scaling based on ML predictions."""
+
+    def __init__(
+        self,
+        *,
+        advisor: LearnedAdvisor | ResourceAdvisor,
+        min_workers: dict[str, int] | None = None,
+        max_workers: dict[str, int] | None = None,
+        scale_up_threshold: float = 0.8,    # queue depth ratio
+        scale_down_threshold: float = 0.2,
+        cooldown_seconds: float = 60.0,
+    ) -> None: ...
+
+    def evaluate(
+        self,
+        *,
+        pending_tasks: list[dict[str, Any]],
+        active_workers: dict[str, int],
+        recent_completions: list[dict[str, Any]],
+    ) -> ScaleDecision: ...
+
+@dataclass(frozen=True)
+class ScaleDecision:
+    """A scaling recommendation with reasoning."""
+    workers_to_add: dict[str, int]
+    workers_to_remove: dict[str, int]
+    reasoning: str
+    confidence: float
+    predicted_completion_time: float | None
+```
+
+Adaptive scaling workflow:
+1. Monitor task queue depth per component/tag
+2. Predict remaining runtime for active tasks using `LearnedAdvisor`
+3. Calculate if adding/removing workers improves predicted throughput
+4. Respect min/max bounds and cooldown periods
+5. Emit scaling decision with explanation
+
+### 3.5 Emulator registry and decorator (`emulation/`)
+
+```python
+# emulation/decorator.py
+def emulatable(
+    *,
+    tag: str,
+    inputs: list[str],
+    outputs: list[str],
+    uncertainty: str = "required",    # "required" | "optional" | "none"
+    fallback: str = "full_model",     # "full_model" | "error" | "cached"
+    domain: dict[str, Any] | None = None,  # input domain bounds
+    confidence_threshold: float = 0.9,
+):
+    """Decorator marking a function as emulation-capable."""
+    ...
+
+# emulation/registry.py
+class EmulatorRegistry:
+    """Manages trained emulator models with versioning and domain validation."""
+
+    def register(
+        self,
+        name: str,
+        emulator: TrainedEmulator,
+        *,
+        version: str | None = None,
+        domain: dict[str, Any] | None = None,
+    ) -> str: ...
+
+    def get(self, name: str, *, version: str | None = None) -> TrainedEmulator: ...
+    def list(self) -> list[EmulatorInfo]: ...
+    def validate_domain(self, name: str, inputs: dict[str, Any]) -> bool: ...
+
+# emulation/surrogate.py
+class TrainedEmulator(Protocol):
+    """Protocol for trained surrogate models."""
+    def predict(self, inputs: dict[str, Any]) -> EmulatorPrediction: ...
+    def uncertainty(self, inputs: dict[str, Any]) -> float: ...
+    @property
+    def metadata(self) -> EmulatorMetadata: ...
+
+@dataclass(frozen=True)
+class EmulatorPrediction:
+    """Prediction result with uncertainty information."""
+    outputs: dict[str, Any]
+    confidence: float
+    uncertainty_bounds: dict[str, tuple[float, float]] | None
+    is_emulated: bool = True
+
+@dataclass(frozen=True)
+class EmulatorMetadata:
+    """Provenance and quality metadata for a trained emulator."""
+    name: str
+    version: str
+    training_runs: list[str]
+    training_samples: int
+    validation_score: float
+    domain_bounds: dict[str, tuple[float, float]]
+    created_at: str
+    model_type: str
+```
+
+### 3.6 Uncertainty-aware dispatch (`emulation/dispatch.py`)
+
+```python
+class EmulatorDispatch:
+    """Routes function calls to emulator or full model based on confidence."""
+
+    def __init__(
+        self,
+        registry: EmulatorRegistry,
+        *,
+        confidence_threshold: float = 0.9,
+        record_provenance: bool = True,
+    ) -> None: ...
+
+    def execute(
+        self,
+        func: Callable,
+        *args,
+        emulator_name: str | None = None,
+        force_full_model: bool = False,
+        **kwargs,
+    ) -> EmulatorDispatchResult: ...
+
+@dataclass(frozen=True)
+class EmulatorDispatchResult:
+    """Result of an emulator-dispatched call with provenance."""
+    result: Any
+    source: str          # "emulator" | "full_model" | "cached"
+    confidence: float | None
+    emulator_version: str | None
+    fallback_reason: str | None
+```
+
+Dispatch logic:
+1. Check if input is within declared emulator domain
+2. If in domain, query emulator for prediction + uncertainty
+3. If confidence ≥ threshold, return emulated result with provenance
+4. If confidence < threshold, execute full model and record as training data
+5. If no emulator registered, always execute full model
+6. Record dispatch decision in telemetry (new `EmulationEvent`)
+
+### 3.7 Active learning (`emulation/active_learning.py`)
+
+```python
+class ActiveLearner:
+    """Select next-best scenarios to maximize emulator training efficiency."""
+
+    def __init__(
+        self,
+        emulator: TrainedEmulator,
+        *,
+        acquisition: str = "expected_improvement",  # or "uncertainty", "random"
+        batch_size: int = 1,
+    ) -> None: ...
+
+    def suggest(
+        self,
+        candidates: pd.DataFrame,
+        *,
+        n_suggestions: int = 1,
+    ) -> pd.DataFrame:
+        """Select the most informative candidates for full-model evaluation."""
+        ...
+
+    def update(self, new_observations: pd.DataFrame) -> None:
+        """Incorporate new full-model results into acquisition state."""
+        ...
+```
+
+Acquisition strategies:
+- **Expected improvement** — maximize expected reduction in emulator uncertainty
+- **Maximum uncertainty** — sample where emulator is least confident
+- **Random baseline** — for comparison and diversity
+
+### 3.8 Distributed tuning (`ml/tuning.py`)
+
+```python
+class HyperparameterSearch:
+    """Distributed hyperparameter tuning via Dask-ML."""
+
+    def __init__(
+        self,
+        estimator: Any,        # sklearn-compatible estimator
+        param_space: dict[str, Any],
+        *,
+        strategy: str = "hyperband",  # or "successive_halving", "random"
+        n_iter: int = 50,
+        scoring: str | None = None,
+    ) -> None: ...
+
+    def fit(
+        self,
+        X: pd.DataFrame | Any,
+        y: pd.Series | Any,
+        *,
+        client: ScalableClient | None = None,
+    ) -> TuningResult: ...
+
+@dataclass(frozen=True)
+class TuningResult:
+    """Result of a hyperparameter search."""
+    best_params: dict[str, Any]
+    best_score: float
+    all_results: pd.DataFrame
+    best_estimator: Any
+    n_iterations: int
+    wall_time_s: float
+```
+
+### 3.9 Telemetry extensions
+
+New event type for Phase 5:
+
+```python
+@dataclass(frozen=True)
+class EmulationEvent:
+    """Emulation dispatch event record (Phase 5)."""
+    run_id: str
+    task_name: str
+    component: str | None
+    emulator_name: str | None
+    source: str            # "emulator" | "full_model" | "cached"
+    confidence: float | None
+    fallback_reason: str | None
+    timestamp: str
+    domain_valid: bool
+    event_type: str = "emulation"
+    schema_version: int = SCHEMA_VERSION
+```
+
+### 3.10 Settings extensions
+
+| Setting | Env var | Default | Purpose |
+|---------|---------|---------|---------|
+| `ml_model_cache_dir` | `SCALABLE_ML_CACHE_DIR` | `.scalable/models` | Cached trained ML models |
+| `emulator_registry_dir` | `SCALABLE_EMULATOR_DIR` | `.scalable/emulators` | Trained emulator storage |
+| `ml_enabled` | `SCALABLE_ML` | `1` | Enable/disable ML features |
+| `emulation_enabled` | `SCALABLE_EMULATION` | `0` | Enable/disable emulation (opt-in) |
+| `emulation_confidence_threshold` | `SCALABLE_EMULATION_CONFIDENCE` | `0.9` | Default confidence threshold |
+
+---
+
+## 4. Ordered work breakdown
+
+1. **WU-1 — Branch and package scaffolding**
+   - Create `version/2.0.0-phase5-ml-emulation` from `version/2.0.0`
+   - Create `scalable/ml/` and `scalable/emulation/` package scaffolds
+   - Bump version to `2.0.0a5`
+   - Add `ml` optional extra to `pyproject.toml`
+
+2. **WU-2 — Feature extraction engine**
+   - Implement `scalable/ml/features.py`
+   - Extract engineered features from telemetry DataFrames
+   - Build feature vectors from task arguments
+   - Unit tests for feature engineering
+
+3. **WU-3 — ML model wrappers**
+   - Implement `scalable/ml/models.py`
+   - Gradient boosting, quantile regression, random forest wrappers
+   - Sklearn-compatible interface with `fit`/`predict`/`predict_intervals`
+   - Model serialization/deserialization
+   - Unit tests
+
+4. **WU-4 — Model validation and quality**
+   - Implement `scalable/ml/validation.py`
+   - Cross-validation framework
+   - `ModelQuality` dataclass with metrics (MAE, coverage, calibration)
+   - Comparison against heuristic baseline
+   - Unit tests
+
+5. **WU-5 — Learned resource advisor**
+   - Implement `scalable/ml/learned_advisor.py`
+   - `LearnedAdvisor.from_history()` trains from telemetry
+   - `recommend()` produces `ResourceRecommendation` with ML predictions
+   - `explain()` returns feature importances
+   - Model caching for fast re-load
+   - Unit tests
+
+6. **WU-6 — Adaptive scaling policy**
+   - Implement `scalable/ml/adaptive_scaler.py`
+   - `AdaptiveScaler` with configurable thresholds and bounds
+   - `ScaleDecision` with reasoning
+   - Integration with `LearnedAdvisor` for completion time prediction
+   - Unit tests
+
+7. **WU-7 — Hyperparameter tuning integration**
+   - Implement `scalable/ml/tuning.py`
+   - Dask-ML wrapper for distributed search
+   - Support hyperband, successive halving, random strategies
+   - `TuningResult` payload
+   - Unit tests (mocked Dask client)
+
+8. **WU-8 — Surrogate model abstractions**
+   - Implement `scalable/emulation/surrogate.py`
+   - `TrainedEmulator` protocol
+   - `GaussianProcessEmulator`, `GradientBoostingEmulator`, `RandomForestEmulator`
+   - `EmulatorPrediction` and `EmulatorMetadata` dataclasses
+   - Unit tests
+
+9. **WU-9 — Emulator registry**
+   - Implement `scalable/emulation/registry.py`
+   - `EmulatorRegistry` with versioning and persistence
+   - Domain validation
+   - Serialization to/from `.scalable/emulators/`
+   - Unit tests
+
+10. **WU-10 — `@emulatable` decorator**
+    - Implement `scalable/emulation/decorator.py`
+    - Decorator that registers functions with emulation metadata
+    - Domain bounds declaration
+    - Confidence threshold configuration
+    - Unit tests
+
+11. **WU-11 — Uncertainty-aware dispatch**
+    - Implement `scalable/emulation/dispatch.py`
+    - `EmulatorDispatch` routing logic
+    - Confidence-gated fallback to full model
+    - Provenance recording
+    - Unit tests
+
+12. **WU-12 — Uncertainty calibration**
+    - Implement `scalable/emulation/uncertainty.py`
+    - Confidence calibration utilities
+    - Coverage checking for prediction intervals
+    - Domain boundary detection
+    - Unit tests
+
+13. **WU-13 — Active learning**
+    - Implement `scalable/emulation/active_learning.py`
+    - `ActiveLearner` with acquisition strategies
+    - Expected improvement, maximum uncertainty, random
+    - Batch suggestion support
+    - Unit tests
+
+14. **WU-14 — Telemetry extensions**
+    - Add `EmulationEvent` to `scalable/telemetry/events.py`
+    - Add `emulation.jsonl` stream to `TelemetryStore`
+    - Add emulation summary to `scalable report`
+    - Unit tests
+
+15. **WU-15 — Settings and configuration**
+    - Add Phase 5 settings to `scalable/common.py`
+    - ML/emulation env var support
+    - Configuration validation
+    - Unit tests
+
+16. **WU-16 — CLI `scalable advise` command**
+    - Implement `scalable/cli/cmd_advise.py`
+    - ML-backed resource recommendations from CLI
+    - Flags: `--task`, `--target`, `--runs-dir`, `--model-type`, `--format`
+    - Graceful degradation to heuristic when ML unavailable
+    - Unit tests
+
+17. **WU-17 — Integration with `ResourceAdvisor` and session**
+    - Add `LearnedAdvisor` as opt-in replacement in `scalable/advising/resources.py`
+    - Wire into `ScalableSession.plan(objective=, policy=)` when ML enabled
+    - Maintain backward compatibility with Phase 2 heuristic path
+    - Integration tests
+
+18. **WU-18 — Public API surface updates**
+    - Export ML/emulation types from `scalable/__init__.py`
+    - Update `__all__` with new exports
+    - Graceful import when `scalable[ml]` not installed
+    - Unit tests for import paths
+
+19. **WU-19 — Test suite**
+    - Full unit test coverage for all new modules
+    - Integration test: emulator train → predict → fallback cycle
+    - Regression tests for Phase 1–4 behavior
+    - Cross-validation test for LearnedAdvisor quality
+
+20. **WU-20 — Documentation and changelog**
+    - New docs: `docs/ml_optimization.rst`, `docs/emulation.rst`
+    - Update `README.md` with ML/emulation examples
+    - Update `docs/index.rst` navigation
+    - Add `2.0.0a5` changelog entry
+
+21. **WU-21 — Phase 5 PR**
+    - Open PR from `version/2.0.0-phase5-ml-emulation` to `version/2.0.0`
+    - Validate all success criteria
+    - Merge after review
+
+---
+
+## 5. Files to create, modify, and remove
+
+### 5.1 Files to create
+
+**ML package:**
+- `scalable/ml/__init__.py`
+- `scalable/ml/learned_advisor.py`
+- `scalable/ml/adaptive_scaler.py`
+- `scalable/ml/features.py`
+- `scalable/ml/models.py`
+- `scalable/ml/validation.py`
+- `scalable/ml/tuning.py`
+
+**Emulation package:**
+- `scalable/emulation/__init__.py`
+- `scalable/emulation/registry.py`
+- `scalable/emulation/decorator.py`
+- `scalable/emulation/dispatch.py`
+- `scalable/emulation/active_learning.py`
+- `scalable/emulation/surrogate.py`
+- `scalable/emulation/uncertainty.py`
+
+**CLI:**
+- `scalable/cli/cmd_advise.py`
+
+**Tests:**
+- `tests/unit/test_ml_features.py`
+- `tests/unit/test_ml_models.py`
+- `tests/unit/test_ml_validation.py`
+- `tests/unit/test_ml_learned_advisor.py`
+- `tests/unit/test_ml_adaptive_scaler.py`
+- `tests/unit/test_ml_tuning.py`
+- `tests/unit/test_emulation_surrogate.py`
+- `tests/unit/test_emulation_registry.py`
+- `tests/unit/test_emulation_decorator.py`
+- `tests/unit/test_emulation_dispatch.py`
+- `tests/unit/test_emulation_uncertainty.py`
+- `tests/unit/test_emulation_active_learning.py`
+- `tests/unit/test_cli_advise.py`
+- `tests/unit/test_telemetry_emulation.py`
+- `tests/integration/test_emulator_lifecycle.py`
+
+**Docs:**
+- `docs/ml_optimization.rst`
+- `docs/emulation.rst`
+
+**Plan:**
+- `plans/v2.0.0_phase5_plan.md` (this document)
+
+### 5.2 Files to modify
+
+- [`pyproject.toml`](pyproject.toml) — bump version to `2.0.0a5`; add `ml` optional extra with `scikit-learn`, `dask-ml`
+- [`scalable/__init__.py`](scalable/__init__.py) — add Phase 5 ML/emulation exports (gated)
+- [`scalable/common.py`](scalable/common.py) — add Phase 5 settings (ML/emulation env vars)
+- [`scalable/advising/__init__.py`](scalable/advising/__init__.py) — export `LearnedAdvisor`
+- [`scalable/advising/resources.py`](scalable/advising/resources.py) — add `LearnedAdvisor` integration hook
+- [`scalable/telemetry/events.py`](scalable/telemetry/events.py) — add `EmulationEvent`
+- [`scalable/telemetry/store.py`](scalable/telemetry/store.py) — add `emulation.jsonl` stream
+- [`scalable/telemetry/collectors.py`](scalable/telemetry/collectors.py) — add emulation summary
+- [`scalable/session/session.py`](scalable/session/session.py) — integrate `LearnedAdvisor` into planning
+- [`scalable/cli/main.py`](scalable/cli/main.py) — add `advise` command
+- [`README.md`](README.md) — add ML/emulation examples
+- [`CHANGELOG.md`](CHANGELOG.md) — `2.0.0a5` entry
+- [`docs/index.rst`](docs/index.rst) — include new pages
+
+### 5.3 Files to remove
+
+- None. Phase 5 is strictly additive.
+
+---
+
+## 6. New dependencies, configuration, and migrations
+
+### 6.1 Dependencies
+
+**New optional extra `[project.optional-dependencies] ml`:**
+```toml
+ml = [
+    "scikit-learn >= 1.3",
+    "dask-ml >= 2023.3.24",
+]
+```
+
+Design rationale:
+- `scikit-learn` — core ML algorithms (gradient boosting, random forest, quantile regression, Gaussian processes)
+- `dask-ml` — distributed hyperparameter search, incremental learning, scalable model selection
+
+The ML features degrade to Phase 2 heuristics when `scalable[ml]` is not installed. All ML imports are lazy and gated behind `try/except ImportError`.
+
+### 6.2 Configuration additions
+
+| Setting | Env var | Default | Purpose |
+|---------|---------|---------|---------|
+| `ml_model_cache_dir` | `SCALABLE_ML_CACHE_DIR` | `.scalable/models` | Cached trained ML models |
+| `emulator_registry_dir` | `SCALABLE_EMULATOR_DIR` | `.scalable/emulators` | Trained emulator storage |
+| `ml_enabled` | `SCALABLE_ML` | `1` | Enable/disable ML features |
+| `emulation_enabled` | `SCALABLE_EMULATION` | `0` | Enable emulation (off by default) |
+| `emulation_confidence_threshold` | `SCALABLE_EMULATION_CONFIDENCE` | `0.9` | Confidence threshold for emulator dispatch |
+
+### 6.3 Migrations
+
+- No data migration required.
+- `ResourceAdvisor` from Phase 2 remains fully functional; `LearnedAdvisor` is an opt-in upgrade.
+- `scalable advise` is a new CLI command (no existing stub to replace).
+- Emulation features are entirely opt-in (`SCALABLE_EMULATION=1`).
+- Existing `ScalableSession.plan(objective=, policy=)` gains ML-backed behavior when trained models are available, but falls back to Phase 4 heuristics otherwise.
+
+---
+
+## 7. Testing strategy
+
+| Layer | Coverage focus |
+|-------|----------------|
+| **Unit** | Feature extraction, model wrappers (fit/predict contract), validation metrics, advisor recommendations, emulator protocol, registry CRUD, decorator metadata, dispatch routing, active learning acquisition, tuning result parsing, CLI argument handling, settings validation |
+| **Integration** | End-to-end emulator lifecycle: register → train → predict → fallback; LearnedAdvisor train from synthetic telemetry and recommend; `scalable advise` CLI with fixture history |
+| **Regression** | Phase 1–4 behavior unchanged; Phase 2 `ResourceAdvisor` still works identically; existing tests pass |
+| **Quality** | Cross-validation showing LearnedAdvisor outperforms heuristic on synthetic workload data |
+| **Mock** | Dask-ML search mocked for CI (no real distributed cluster required); sklearn estimators used directly in unit tests |
+| **Static** | `mypy` and `ruff` clean over new `scalable/ml/` and `scalable/emulation/` modules |
+
+Key test scenarios:
+- `LearnedAdvisor` with sufficient history → better-than-heuristic predictions
+- `LearnedAdvisor` with insufficient history → graceful fallback to `ResourceAdvisor`
+- `AdaptiveScaler` with high queue depth → scale-up decision
+- `AdaptiveScaler` with idle workers → scale-down decision respecting cooldown
+- `@emulatable` decorated function → metadata accessible via registry
+- Emulator dispatch with high confidence → emulated result
+- Emulator dispatch with low confidence → full model execution + provenance
+- Emulator dispatch outside domain → immediate fallback
+- Active learner → selects high-uncertainty candidates
+- All features graceful when `scalable[ml]` not installed
+
+---
+
+## 8. Documentation updates
+
+- **New:** [`docs/ml_optimization.rst`](docs/ml_optimization.rst) — full guide covering:
+  - `LearnedAdvisor` usage and training
+  - Feature extraction configuration
+  - Adaptive scaling policies
+  - Hyperparameter tuning integration
+  - Model quality assessment
+  - Graceful degradation behavior
+- **New:** [`docs/emulation.rst`](docs/emulation.rst) — full guide covering:
+  - `@emulatable` decorator usage
+  - Emulator registry management
+  - Uncertainty-aware dispatch
+  - Active learning for scenario selection
+  - Supported surrogate model types
+  - Domain bounds and validation
+  - Provenance and reproducibility
+- **Updated:** [`README.md`](README.md) — ML advisor and emulation examples
+- **Updated:** [`docs/index.rst`](docs/index.rst) — include new pages in toctree
+- **Updated:** [`docs/advising.rst`](docs/advising.rst) — cross-link to ML optimization
+- **Updated:** [`CHANGELOG.md`](CHANGELOG.md) — `2.0.0a5` entry
+
+---
+
+## 9. Risks, open questions, and assumptions
+
+### 9.1 Risks
+
+| Risk | Likelihood | Mitigation |
+|------|------------|------------|
+| Insufficient telemetry data for meaningful ML training | High (early adoption) | Graceful fallback to heuristics; require minimum sample count before ML activates |
+| Overfitting on small telemetry histories | Medium | Conservative model selection; cross-validation mandatory before deployment; wide confidence intervals when data is sparse |
+| Scikit-learn version incompatibility with serialized models | Medium | Pin minimum sklearn version; include model metadata with sklearn version; retrain on version mismatch |
+| Emulator confidence miscalibration | Medium | Require held-out validation before registry registration; coverage checks at prediction time; conservative default threshold (0.9) |
+| Dask-ML API instability | Low | Pin minimum version; wrap in thin abstraction layer; fallback to sequential search if Dask-ML unavailable |
+| Performance overhead from ML inference in hot paths | Low | Cache predictions; batch feature extraction; lazy model loading |
+| Complex interaction between adaptive scaler and provider scaling | Medium | Respect provider min/max bounds; implement cooldown; require explicit opt-in for adaptive scaling |
+
+### 9.2 Open questions
+
+1. **Minimum sample count for ML activation.** Proposal: require ≥ 10 completed tasks for the same task/component before activating ML predictions. Below that, fall back to quantile heuristics.
+2. **Model retraining frequency.** Proposal: retrain on-demand via `LearnedAdvisor.from_history(retrain=True)` or when model cache is stale (configurable staleness window). No automatic background retraining in Phase 5.
+3. **Emulator storage format.** Proposal: joblib serialization for sklearn models stored under `.scalable/emulators/<name>/<version>/model.joblib` + `metadata.json`.
+4. **Should adaptive scaling be auto-activated?** Proposal: No — require explicit `AdaptiveScaler` instantiation or `SCALABLE_ADAPTIVE_SCALING=1` env var. Phase 5 is opt-in only.
+5. **Gaussian Process scalability.** For large emulator training sets (>1000 samples), GP becomes expensive. Proposal: auto-switch to sparse GP or gradient boosting when training set exceeds threshold.
+6. **Should `scalable advise` be a new command or enhance `scalable report`?** Proposal: New dedicated command for clarity, with `scalable report` continuing to show historical summaries and `scalable advise` providing forward-looking recommendations.
+
+### 9.3 Assumptions
+
+- Phase 1–4 code on `version/2.0.0` (with Phase 4 merged) is the implementation baseline.
+- Python 3.11+ remains the runtime target.
+- scikit-learn 1.3+ provides all needed model implementations (GradientBoostingRegressor, QuantileRegressor, RandomForestRegressor, GaussianProcessRegressor).
+- No live Dask cluster or Slurm allocation required for Phase 5 CI; all ML tests use synthetic data and mocked distributed execution.
+- Users accept that ML predictions may be less accurate than manual tuning early in adoption; the system improves with more history.
+
+---
+
+## 10. Phase 5 as the capstone — what it completes
+
+Phase 5 completes the v2.0.0 vision of Scalable as a "portable scientific-model execution control plane" with optional ML services:
+
+| Master plan capability | Phase 5 deliverable |
+|------------------------|---------------------|
+| "Learned resource prediction" (§5) | `LearnedAdvisor` with gradient boosting + calibrated intervals |
+| "Adaptive correction" (§5.4) | `AdaptiveScaler` with ML-predicted completion times |
+| "Feature-based regression" (§5.2) | `FeatureExtractor` + engineered features from telemetry |
+| "Uncertainty-aware planning" (§5.3) | Calibrated prediction intervals + confidence-based decisions |
+| "Active-learning scenario selection" (§9) | `ActiveLearner` with acquisition strategies |
+| "Emulator registry" (§9) | `EmulatorRegistry` with versioning and domain validation |
+| "Uncertainty-aware full-model fallback" (§9) | `EmulatorDispatch` with confidence gating |
+| "Distributed hyperparameter tuning" (§9) | `HyperparameterSearch` via Dask-ML |
+| "Emulators opt-in, uncertainty-aware, labeled" (§9 guardrail) | Default off; provenance recorded; results labeled |
+
+After Phase 5 merges, the `version/2.0.0` branch contains the complete v2.0.0 feature set and can proceed toward release candidate status.
+
+---
+
+## 11. Branching and PR workflow
+
+```text
+origin/version/2.0.0  ──────────────────────────────────────────►  long-lived integration
+        │
+        └── version/2.0.0-phase5-ml-emulation  ── PR ────────────┘  phase 5 work (final)
+```
+
+- Develop all Phase 5 commits on `version/2.0.0-phase5-ml-emulation`.
+- Open a dedicated PR targeting `version/2.0.0`.
+- After merge, `version/2.0.0` contains the complete 2.0.0 feature set.
+- Next step after Phase 5: stabilization, release candidates, final merge to `main`.
+
+---
+
+## 12. Phase 5 architecture diagram
+
+```mermaid
+flowchart TB
+    subgraph ML_Optimization
+        FE[FeatureExtractor]
+        MW[Model Wrappers sklearn]
+        LA[LearnedAdvisor]
+        AS[AdaptiveScaler]
+        VL[ModelValidation]
+        HT[HyperparameterSearch Dask-ML]
+    end
+
+    subgraph Emulation
+        DEC[@emulatable decorator]
+        REG[EmulatorRegistry]
+        SUR[Surrogate Models GP RF NN]
+        DSP[EmulatorDispatch]
+        UNC[Uncertainty Calibration]
+        ACT[ActiveLearner]
+    end
+
+    subgraph Phase_1_4_Foundation
+        TS[Telemetry Store tasks.jsonl]
+        RA[ResourceAdvisor heuristic]
+        SS[ScalableSession.plan]
+        PV[Providers scale]
+        CE[CostEstimate]
+        AB[AIBackend]
+    end
+
+    subgraph Outputs
+        RR[ResourceRecommendation]
+        SD[ScaleDecision]
+        EP[EmulatorPrediction]
+        AL[ActiveLearning suggestions]
+        TR[TuningResult]
+    end
+
+    TS --> FE
+    FE --> MW
+    MW --> LA
+    LA --> RR
+    LA --> AS
+    AS --> SD
+    AS --> PV
+
+    RA -.->|fallback| LA
+    SS --> LA
+    CE --> AS
+
+    DEC --> REG
+    REG --> DSP
+    SUR --> DSP
+    UNC --> DSP
+    DSP --> EP
+    ACT --> AL
+    SUR --> ACT
+
+    MW --> HT
+    HT --> TR
+
+    AB -.->|optional enhancement| LA
+```
+
+---
+
+## 13. Phase 5 execution checklist
+
+1. Create branch `version/2.0.0-phase5-ml-emulation` from `version/2.0.0`.
+2. Scaffold `scalable/ml/` and `scalable/emulation/` packages.
+3. Add `ml` optional extra to `pyproject.toml`; bump version to `2.0.0a5`.
+4. Implement feature extraction engine.
+5. Implement ML model wrappers with sklearn.
+6. Implement model validation and quality framework.
+7. Implement `LearnedAdvisor` with training and prediction.
+8. Implement `AdaptiveScaler` with configurable policies.
+9. Implement distributed hyperparameter tuning integration.
+10. Implement surrogate model abstractions.
+11. Implement emulator registry with versioning.
+12. Implement `@emulatable` decorator.
+13. Implement uncertainty-aware dispatch.
+14. Implement uncertainty calibration utilities.
+15. Implement active learning with acquisition strategies.
+16. Add telemetry extensions (`EmulationEvent`, `emulation.jsonl`).
+17. Add Phase 5 settings to `common.py`.
+18. Implement `scalable advise` CLI command.
+19. Wire `LearnedAdvisor` into session planning and advising exports.
+20. Update public API exports.
+21. Add comprehensive unit + integration tests.
+22. Add documentation and update changelog.
+23. Open Phase 5 PR and validate all success criteria.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "scalable"
-version = "2.0.0a4"
+version = "2.0.0a5"
 description = "Assist with running models on job queing systems like Slurm"
 authors = [
     { name = "Shashank Lamba" },
@@ -71,6 +71,11 @@ cloud = [
 kubernetes = [
     "dask-kubernetes >= 2024.1.0",
     "kubernetes >= 27.0",
+]
+ml = [
+    "scikit-learn >= 1.3",
+    "dask-ml >= 2023.3.24",
+    "joblib >= 1.3",
 ]
 
 [project.urls]

--- a/scalable/__init__.py
+++ b/scalable/__init__.py
@@ -80,6 +80,27 @@ except ImportError:  # pragma: no cover
     migrate_manifest = None  # type: ignore[assignment,misc]
     onboard_component = None  # type: ignore[assignment,misc]
 
+# Phase 5: ML optimization and emulation exports (optional deps)
+try:
+    from .ml import AdaptiveScaler, HyperparameterSearch, LearnedAdvisor
+except ImportError:  # pragma: no cover
+    LearnedAdvisor = None  # type: ignore[assignment,misc]
+    AdaptiveScaler = None  # type: ignore[assignment,misc]
+    HyperparameterSearch = None  # type: ignore[assignment,misc]
+
+try:
+    from .emulation import (
+        ActiveLearner,
+        EmulatorDispatch,
+        EmulatorRegistry,
+        emulatable,
+    )
+except ImportError:  # pragma: no cover
+    ActiveLearner = None  # type: ignore[assignment,misc]
+    EmulatorDispatch = None  # type: ignore[assignment,misc]
+    EmulatorRegistry = None  # type: ignore[assignment,misc]
+    emulatable = None  # type: ignore[assignment,misc]
+
 try:
     __version__ = _pkg_version("scalable")
 except PackageNotFoundError:  # pragma: no cover - source checkout w/o install
@@ -97,6 +118,7 @@ __all__ = [
     "GCPProvider",
     "JobQueueCluster",
     "KubernetesProvider",
+    "LearnedAdvisor",
     "LocalArtifactStore",
     "LocalProvider",
     "MigrationResult",
@@ -113,9 +135,16 @@ __all__ = [
     "build_artifact_store",
     "compose_workflow",
     "diagnose_run",
+    "emulatable",
     "explain_plan",
     "get_worker",
     "migrate_manifest",
     "onboard_component",
     "settings",
+    # Phase 5 ML/emulation
+    "ActiveLearner",
+    "AdaptiveScaler",
+    "EmulatorDispatch",
+    "EmulatorRegistry",
+    "HyperparameterSearch",
 ]

--- a/scalable/cli/cmd_advise.py
+++ b/scalable/cli/cmd_advise.py
@@ -1,0 +1,174 @@
+"""CLI command: ``scalable advise`` — ML-backed resource recommendations."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from typing import Any
+
+
+def register_advise_parser(subparsers: Any) -> None:
+    """Register the ``advise`` subcommand."""
+    parser = subparsers.add_parser(
+        "advise",
+        help="Get ML-backed resource recommendations for a task",
+        description=(
+            "Analyze telemetry history and provide ML-backed resource "
+            "recommendations. Falls back to heuristic quantiles when "
+            "insufficient data or scalable[ml] is not installed."
+        ),
+    )
+    parser.add_argument(
+        "--task",
+        required=True,
+        help="Task name to get recommendations for",
+    )
+    parser.add_argument(
+        "--target",
+        default=None,
+        help="Deployment target to scope recommendations",
+    )
+    parser.add_argument(
+        "--runs-dir",
+        default=None,
+        help="Path to runs directory (default: .scalable/runs)",
+    )
+    parser.add_argument(
+        "--model-type",
+        default="gradient_boosting",
+        choices=["gradient_boosting", "random_forest", "quantile_regression"],
+        help="ML model type for predictions (default: gradient_boosting)",
+    )
+    parser.add_argument(
+        "--confidence",
+        type=float,
+        default=0.95,
+        help="Confidence level for recommendations (default: 0.95)",
+    )
+    parser.add_argument(
+        "--format",
+        choices=["text", "json"],
+        default="text",
+        dest="output_format",
+        help="Output format (default: text)",
+    )
+    parser.add_argument(
+        "--output",
+        default=None,
+        help="Output file path (default: stdout)",
+    )
+    parser.set_defaults(func=_run_advise)
+
+
+def _run_advise(args: argparse.Namespace) -> int:
+    """Execute the advise command."""
+    from scalable.common import settings
+
+    runs_dir = args.runs_dir or settings.runs_dir
+
+    # Try ML advisor first, fall back to heuristic
+    recommendation = None
+    method = "heuristic"
+
+    try:
+        from scalable.ml.learned_advisor import LearnedAdvisor
+
+        advisor = LearnedAdvisor.from_history(
+            runs_dir,
+            model_type=args.model_type,
+        )
+        recommendation = advisor.recommend(
+            task=args.task,
+            target=args.target,
+            confidence=args.confidence,
+        )
+        method = recommendation.evidence.get("method", "ml")
+    except (ImportError, Exception):
+        # Fall back to Phase 2 heuristic advisor
+        try:
+            from scalable.advising.resources import ResourceAdvisor
+
+            advisor_h = ResourceAdvisor.from_history(runs_dir)
+            recommendation = advisor_h.recommend(
+                task=args.task,
+                target=args.target,
+                confidence=args.confidence,
+            )
+            method = "heuristic"
+        except Exception as e:
+            sys.stderr.write(f"Error: Could not load run history: {e}\n")
+            return 1
+
+    if recommendation is None:
+        sys.stderr.write("Error: No recommendation could be generated\n")
+        return 1
+
+    # Format output
+    if args.output_format == "json":
+        output = json.dumps(
+            {
+                "task": recommendation.task,
+                "target": recommendation.target,
+                "confidence": recommendation.confidence,
+                "method": method,
+                "workers": recommendation.workers,
+                "resources": recommendation.resources,
+                "evidence": recommendation.evidence,
+            },
+            indent=2,
+        )
+    else:
+        output = _format_text(recommendation, method)
+
+    if args.output:
+        with open(args.output, "w") as f:
+            f.write(output + "\n")
+    else:
+        sys.stdout.write(output + "\n")
+
+    return 0
+
+
+def _format_text(recommendation: Any, method: str) -> str:
+    """Format recommendation as human-readable text."""
+    lines = [
+        f"Resource Recommendation for: {recommendation.task}",
+        f"{'=' * 50}",
+        f"Method: {method}",
+        f"Confidence: {recommendation.confidence:.2f}",
+        f"Target: {recommendation.target or 'any'}",
+        "",
+        "Workers:",
+    ]
+
+    for tag, count in recommendation.workers.items():
+        lines.append(f"  {tag}: {count}")
+
+    lines.append("")
+    lines.append("Resources:")
+    for tag, res in recommendation.resources.items():
+        lines.append(f"  {tag}:")
+        lines.append(f"    CPUs: {res.get('cpus', 'N/A')}")
+        lines.append(f"    Memory: {res.get('memory', 'N/A')}")
+        lines.append(f"    Walltime: {res.get('walltime', 'N/A')}")
+
+    if recommendation.evidence:
+        lines.append("")
+        lines.append("Evidence:")
+        records = recommendation.evidence.get("records", 0)
+        lines.append(f"  Historical records: {records}")
+        if "predicted_duration_s" in recommendation.evidence:
+            dur = recommendation.evidence["predicted_duration_s"]
+            lines.append(f"  Predicted duration: {dur:.1f}s")
+        if "feature_importances" in recommendation.evidence:
+            importances = recommendation.evidence["feature_importances"]
+            if importances:
+                lines.append("  Top features:")
+                sorted_features = sorted(
+                    importances.items(), key=lambda x: x[1], reverse=True
+                )[:5]
+                for feat, imp in sorted_features:
+                    lines.append(f"    {feat}: {imp:.3f}")
+
+    return "\n".join(lines)

--- a/scalable/cli/main.py
+++ b/scalable/cli/main.py
@@ -11,6 +11,7 @@ Implemented subcommands:
 * ``scalable explain``
 * ``scalable compose``
 * ``scalable migrate``
+* ``scalable advise``
 
 """
 
@@ -408,12 +409,23 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     migrate_parser.set_defaults(handler=_handle_migrate)
 
+    # --- advise (Phase 5) ---
+    from .cmd_advise import register_advise_parser
+
+    register_advise_parser(subparsers)
+
     # --- stubs for future phases ---
     for command, phase in _STUB_COMMANDS.items():
         stub_parser = subparsers.add_parser(command, help=f"Reserved command (planned for {phase})")
         stub_parser.set_defaults(handler=_make_stub_handler(command, phase))
 
     return parser
+
+
+def _handle_advise(args: argparse.Namespace) -> int:
+    from .cmd_advise import _run_advise
+
+    return _run_advise(args)
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -426,6 +438,9 @@ def main(argv: list[str] | None = None) -> int:
         return int(exc.code)
 
     handler = getattr(args, "handler", None)
+    # Also check for Phase 5 "func" pattern
+    if handler is None:
+        handler = getattr(args, "func", None)
     if handler is None:
         parser.print_help(sys.stderr)
         return 2

--- a/scalable/common.py
+++ b/scalable/common.py
@@ -96,6 +96,22 @@ class Settings:
     ai_endpoint: str | None = field(
         default_factory=lambda: os.environ.get("SCALABLE_AI_ENDPOINT")
     )
+    # Phase 5 ML/Emulation additions
+    ml_model_cache_dir: str = field(
+        default_factory=lambda: os.environ.get("SCALABLE_ML_CACHE_DIR", ".scalable/models")
+    )
+    emulator_registry_dir: str = field(
+        default_factory=lambda: os.environ.get("SCALABLE_EMULATOR_DIR", ".scalable/emulators")
+    )
+    ml_enabled: bool = field(
+        default_factory=lambda: bool(int(os.environ.get("SCALABLE_ML", "1")))
+    )
+    emulation_enabled: bool = field(
+        default_factory=lambda: bool(int(os.environ.get("SCALABLE_EMULATION", "0")))
+    )
+    emulation_confidence_threshold: float = field(
+        default_factory=lambda: float(os.environ.get("SCALABLE_EMULATION_CONFIDENCE", "0.9"))
+    )
 
 
 #: Process-wide settings singleton. Mutating attributes on this instance

--- a/scalable/emulation/__init__.py
+++ b/scalable/emulation/__init__.py
@@ -1,0 +1,41 @@
+"""Model emulation subsystem for Scalable (Phase 5).
+
+This package provides scientific model emulation capabilities including:
+
+* :class:`EmulatorRegistry` — manage trained surrogate models
+* :func:`emulatable` — decorator marking functions as emulation-capable
+* :class:`EmulatorDispatch` — uncertainty-aware routing
+* :class:`ActiveLearner` — intelligent scenario selection
+* Surrogate model abstractions (GP, RF, gradient boosting)
+"""
+
+from __future__ import annotations
+
+from .active_learning import ActiveLearner
+from .decorator import emulatable
+from .dispatch import EmulatorDispatch, EmulatorDispatchResult
+from .registry import EmulatorInfo, EmulatorRegistry
+from .surrogate import (
+    EmulatorMetadata,
+    EmulatorPrediction,
+    GradientBoostingEmulator,
+    RandomForestEmulator,
+    TrainedEmulator,
+)
+from .uncertainty import CalibrationResult, calibrate_emulator
+
+__all__ = [
+    "ActiveLearner",
+    "CalibrationResult",
+    "EmulatorDispatch",
+    "EmulatorDispatchResult",
+    "EmulatorInfo",
+    "EmulatorMetadata",
+    "EmulatorPrediction",
+    "EmulatorRegistry",
+    "GradientBoostingEmulator",
+    "RandomForestEmulator",
+    "TrainedEmulator",
+    "calibrate_emulator",
+    "emulatable",
+]

--- a/scalable/emulation/active_learning.py
+++ b/scalable/emulation/active_learning.py
@@ -1,0 +1,192 @@
+"""Active learning for intelligent scenario selection."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+import pandas as pd
+
+from scalable.emulation.surrogate import TrainedEmulator
+
+
+class ActiveLearner:
+    """Select next-best scenarios to maximize emulator training efficiency.
+
+    Uses acquisition functions to identify which candidate scenarios
+    would be most informative for improving the emulator, reducing the
+    number of expensive full-model runs needed.
+
+    Parameters
+    ----------
+    emulator
+        A trained emulator to query for uncertainty estimates.
+    acquisition
+        Acquisition strategy: ``"expected_improvement"``,
+        ``"uncertainty"``, or ``"random"``.
+    batch_size
+        Default number of suggestions per call.
+    random_state
+        Random state for reproducibility.
+    """
+
+    def __init__(
+        self,
+        emulator: TrainedEmulator,
+        *,
+        acquisition: str = "expected_improvement",
+        batch_size: int = 1,
+        random_state: int = 42,
+    ) -> None:
+        valid_strategies = {"expected_improvement", "uncertainty", "random"}
+        if acquisition not in valid_strategies:
+            raise ValueError(
+                f"acquisition must be one of {sorted(valid_strategies)}, got {acquisition!r}"
+            )
+
+        self._emulator = emulator
+        self._acquisition = acquisition
+        self._batch_size = batch_size
+        self._rng = np.random.default_rng(random_state)
+        self._observations: list[dict[str, Any]] = []
+
+    @property
+    def acquisition_strategy(self) -> str:
+        """Current acquisition strategy."""
+        return self._acquisition
+
+    @property
+    def n_observations(self) -> int:
+        """Number of observations incorporated."""
+        return len(self._observations)
+
+    def suggest(
+        self,
+        candidates: pd.DataFrame,
+        *,
+        n_suggestions: int | None = None,
+    ) -> pd.DataFrame:
+        """Select the most informative candidates for full-model evaluation.
+
+        Parameters
+        ----------
+        candidates
+            DataFrame of candidate scenarios. Each row represents a
+            candidate input configuration. Column names should match
+            the emulator's input names.
+        n_suggestions
+            Number of candidates to select. Defaults to ``batch_size``.
+
+        Returns
+        -------
+        pd.DataFrame
+            Selected candidates (subset of input DataFrame).
+        """
+        n = n_suggestions or self._batch_size
+        n = min(n, len(candidates))
+
+        if n <= 0 or candidates.empty:
+            return candidates.iloc[:0]
+
+        if self._acquisition == "random":
+            return self._suggest_random(candidates, n)
+        elif self._acquisition == "uncertainty":
+            return self._suggest_max_uncertainty(candidates, n)
+        else:  # expected_improvement
+            return self._suggest_expected_improvement(candidates, n)
+
+    def _suggest_random(self, candidates: pd.DataFrame, n: int) -> pd.DataFrame:
+        """Random baseline selection."""
+        indices = self._rng.choice(len(candidates), size=n, replace=False)
+        return candidates.iloc[indices].reset_index(drop=True)
+
+    def _suggest_max_uncertainty(self, candidates: pd.DataFrame, n: int) -> pd.DataFrame:
+        """Select candidates where emulator is least confident."""
+        uncertainties = []
+        for _, row in candidates.iterrows():
+            inputs = row.to_dict()
+            unc = self._emulator.uncertainty(inputs)
+            uncertainties.append(unc)
+
+        uncertainties_arr = np.array(uncertainties)
+        # Select top-n highest uncertainty candidates
+        top_indices = np.argsort(uncertainties_arr)[-n:][::-1]
+        return candidates.iloc[top_indices].reset_index(drop=True)
+
+    def _suggest_expected_improvement(
+        self, candidates: pd.DataFrame, n: int
+    ) -> pd.DataFrame:
+        """Select candidates maximizing expected information gain.
+
+        Uses uncertainty as a proxy for expected improvement when the
+        full acquisition function requires more sophisticated modeling.
+        Also incorporates diversity by penalizing candidates too similar
+        to existing observations.
+        """
+        scores: list[float] = []
+
+        for _, row in candidates.iterrows():
+            inputs = row.to_dict()
+
+            # Uncertainty component
+            unc = self._emulator.uncertainty(inputs)
+
+            # Diversity component (distance from existing observations)
+            diversity = self._compute_diversity(inputs)
+
+            # Combined score: uncertainty * diversity bonus
+            score = unc * (1.0 + 0.3 * diversity)
+            scores.append(score)
+
+        scores_arr = np.array(scores)
+        top_indices = np.argsort(scores_arr)[-n:][::-1]
+        return candidates.iloc[top_indices].reset_index(drop=True)
+
+    def _compute_diversity(self, inputs: dict[str, Any]) -> float:
+        """Compute diversity score based on distance from observations."""
+        if not self._observations:
+            return 1.0  # Maximum diversity when no observations
+
+        # Simple Euclidean-like distance in normalized space
+        input_vec = np.array([
+            float(v) for v in inputs.values() if isinstance(v, (int, float))
+        ])
+
+        if len(input_vec) == 0:
+            return 1.0
+
+        min_dist = float("inf")
+        for obs in self._observations:
+            obs_vec = np.array([
+                float(obs.get(k, 0))
+                for k in inputs.keys()
+                if isinstance(inputs.get(k), (int, float))
+            ])
+            if len(obs_vec) == len(input_vec):
+                dist = float(np.linalg.norm(input_vec - obs_vec))
+                min_dist = min(min_dist, dist)
+
+        if min_dist == float("inf"):
+            return 1.0
+
+        # Normalize to [0, 1] using a sigmoid-like transform
+        return float(1.0 - np.exp(-min_dist / (np.linalg.norm(input_vec) + 1e-10)))
+
+    def update(self, new_observations: pd.DataFrame) -> None:
+        """Incorporate new full-model results into acquisition state.
+
+        Parameters
+        ----------
+        new_observations
+            DataFrame of new observations. Each row should contain
+            the input values that were evaluated with the full model.
+        """
+        for _, row in new_observations.iterrows():
+            self._observations.append(row.to_dict())
+
+    def reset(self) -> None:
+        """Clear all observations and reset state."""
+        self._observations.clear()
+
+
+__all__ = ["ActiveLearner"]

--- a/scalable/emulation/decorator.py
+++ b/scalable/emulation/decorator.py
@@ -1,0 +1,157 @@
+"""@emulatable decorator for marking functions as emulation-capable."""
+
+from __future__ import annotations
+
+import functools
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+# Module-level registry of emulatable functions
+_EMULATABLE_REGISTRY: dict[str, EmulationSpec] = {}
+
+
+@dataclass(frozen=True)
+class EmulationSpec:
+    """Specification for an emulatable function."""
+
+    function_name: str
+    tag: str
+    inputs: list[str]
+    outputs: list[str]
+    uncertainty: str  # "required" | "optional" | "none"
+    fallback: str  # "full_model" | "error" | "cached"
+    domain: dict[str, tuple[float, float]]
+    confidence_threshold: float
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "function_name": self.function_name,
+            "tag": self.tag,
+            "inputs": self.inputs,
+            "outputs": self.outputs,
+            "uncertainty": self.uncertainty,
+            "fallback": self.fallback,
+            "domain": {k: list(v) for k, v in self.domain.items()},
+            "confidence_threshold": self.confidence_threshold,
+        }
+
+
+def emulatable(
+    *,
+    tag: str,
+    inputs: list[str],
+    outputs: list[str],
+    uncertainty: str = "required",
+    fallback: str = "full_model",
+    domain: dict[str, tuple[float, float]] | None = None,
+    confidence_threshold: float = 0.9,
+) -> Callable:
+    """Decorator marking a function as emulation-capable.
+
+    When a trained emulator is available and its confidence exceeds the
+    threshold, the function call can be routed to the emulator instead of
+    the full model. Provenance is recorded for every dispatch decision.
+
+    Parameters
+    ----------
+    tag
+        Component tag for worker routing.
+    inputs
+        List of input parameter names the emulator expects.
+    outputs
+        List of output names the emulator produces.
+    uncertainty
+        Uncertainty requirement: ``"required"`` means emulator must provide
+        calibrated uncertainty bounds; ``"optional"`` allows point estimates;
+        ``"none"`` skips uncertainty checks.
+    fallback
+        Fallback strategy when emulator is unavailable or confidence is low:
+        ``"full_model"`` runs the original function; ``"error"`` raises;
+        ``"cached"`` attempts cache lookup.
+    domain
+        Optional domain bounds for input validation. Dict mapping input
+        names to (min, max) tuples.
+    confidence_threshold
+        Minimum confidence for emulator predictions to be accepted.
+
+    Examples
+    --------
+    >>> @emulatable(
+    ...     tag="gcam",
+    ...     inputs=["carbon_price", "population", "gdp"],
+    ...     outputs=["emissions", "energy_price"],
+    ...     uncertainty="required",
+    ...     fallback="full_model",
+    ...     confidence_threshold=0.9,
+    ... )
+    ... def run_gcam_scenario(params):
+    ...     ...
+    """
+    valid_uncertainty = {"required", "optional", "none"}
+    valid_fallback = {"full_model", "error", "cached"}
+
+    if uncertainty not in valid_uncertainty:
+        raise ValueError(
+            f"uncertainty must be one of {sorted(valid_uncertainty)}, got {uncertainty!r}"
+        )
+    if fallback not in valid_fallback:
+        raise ValueError(
+            f"fallback must be one of {sorted(valid_fallback)}, got {fallback!r}"
+        )
+    if not 0.0 <= confidence_threshold <= 1.0:
+        raise ValueError(
+            f"confidence_threshold must be between 0.0 and 1.0, got {confidence_threshold}"
+        )
+
+    def decorator(func: Callable) -> Callable:
+        spec = EmulationSpec(
+            function_name=func.__qualname__,
+            tag=tag,
+            inputs=inputs,
+            outputs=outputs,
+            uncertainty=uncertainty,
+            fallback=fallback,
+            domain=domain or {},
+            confidence_threshold=confidence_threshold,
+        )
+
+        # Register in module-level registry
+        _EMULATABLE_REGISTRY[func.__qualname__] = spec
+
+        @functools.wraps(func)
+        def wrapper(*args: Any, **kwargs: Any) -> Any:
+            # The actual dispatch logic is handled by EmulatorDispatch
+            # when invoked through a session. Direct calls run the full model.
+            return func(*args, **kwargs)
+
+        # Attach spec as metadata
+        wrapper._emulation_spec = spec  # type: ignore[attr-defined]
+        wrapper._original_func = func  # type: ignore[attr-defined]
+        return wrapper
+
+    return decorator
+
+
+def get_emulation_spec(func: Callable) -> EmulationSpec | None:
+    """Retrieve the emulation spec for a decorated function, if any."""
+    return getattr(func, "_emulation_spec", None)
+
+
+def get_original_function(func: Callable) -> Callable:
+    """Get the original unwrapped function from an @emulatable-decorated callable."""
+    return getattr(func, "_original_func", func)
+
+
+def list_emulatable_functions() -> dict[str, EmulationSpec]:
+    """Return all registered emulatable function specs."""
+    return dict(_EMULATABLE_REGISTRY)
+
+
+__all__ = [
+    "EmulationSpec",
+    "emulatable",
+    "get_emulation_spec",
+    "get_original_function",
+    "list_emulatable_functions",
+]

--- a/scalable/emulation/dispatch.py
+++ b/scalable/emulation/dispatch.py
@@ -1,0 +1,245 @@
+"""Uncertainty-aware emulator dispatch routing."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+from scalable.emulation.decorator import get_emulation_spec, get_original_function
+from scalable.emulation.registry import EmulatorRegistry
+
+
+@dataclass(frozen=True)
+class EmulatorDispatchResult:
+    """Result of an emulator-dispatched call with provenance."""
+
+    result: Any
+    source: str  # "emulator" | "full_model" | "cached"
+    confidence: float | None
+    emulator_version: str | None
+    fallback_reason: str | None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "source": self.source,
+            "confidence": self.confidence,
+            "emulator_version": self.emulator_version,
+            "fallback_reason": self.fallback_reason,
+        }
+
+
+class EmulatorDispatch:
+    """Routes function calls to emulator or full model based on confidence.
+
+    The dispatch decision follows this logic:
+
+    1. Check if the function has an ``@emulatable`` spec
+    2. Check if an emulator is registered for the function
+    3. Validate that inputs are within the emulator's domain
+    4. Query emulator for prediction + uncertainty
+    5. If confidence ≥ threshold, return emulated result
+    6. Otherwise, execute full model (or apply fallback strategy)
+
+    Parameters
+    ----------
+    registry
+        The :class:`EmulatorRegistry` containing trained emulators.
+    confidence_threshold
+        Global confidence threshold override (function-level threshold
+        takes precedence if specified).
+    record_provenance
+        If ``True``, dispatch decisions are recorded for telemetry.
+    """
+
+    def __init__(
+        self,
+        registry: EmulatorRegistry,
+        *,
+        confidence_threshold: float = 0.9,
+        record_provenance: bool = True,
+    ) -> None:
+        self._registry = registry
+        self._confidence_threshold = confidence_threshold
+        self._record_provenance = record_provenance
+        self._dispatch_log: list[EmulatorDispatchResult] = []
+
+    @property
+    def dispatch_log(self) -> list[EmulatorDispatchResult]:
+        """Log of all dispatch decisions made."""
+        return list(self._dispatch_log)
+
+    def execute(
+        self,
+        func: Callable,
+        *args: Any,
+        emulator_name: str | None = None,
+        force_full_model: bool = False,
+        **kwargs: Any,
+    ) -> EmulatorDispatchResult:
+        """Execute a function through the emulator dispatch pipeline.
+
+        Parameters
+        ----------
+        func
+            The function to execute (may be ``@emulatable``-decorated).
+        *args
+            Positional arguments to pass to the function.
+        emulator_name
+            Explicit emulator name. If ``None``, derives from function spec.
+        force_full_model
+            If ``True``, skip emulation and run the full model directly.
+        **kwargs
+            Keyword arguments to pass to the function.
+
+        Returns
+        -------
+        EmulatorDispatchResult
+            The result with provenance information.
+        """
+        spec = get_emulation_spec(func)
+        original_func = get_original_function(func)
+
+        # If forced full model or no emulation spec, run directly
+        if force_full_model or spec is None:
+            result = original_func(*args, **kwargs)
+            dispatch_result = EmulatorDispatchResult(
+                result=result,
+                source="full_model",
+                confidence=None,
+                emulator_version=None,
+                fallback_reason="forced" if force_full_model else "no_emulation_spec",
+            )
+            self._record(dispatch_result)
+            return dispatch_result
+
+        # Determine emulator name
+        emu_name = emulator_name or spec.function_name
+        threshold = spec.confidence_threshold or self._confidence_threshold
+
+        # Try to get emulator from registry
+        try:
+            emulator = self._registry.get(emu_name)
+        except KeyError:
+            return self._fallback(
+                original_func, args, kwargs, spec, reason="emulator_not_registered"
+            )
+
+        # Extract inputs for emulator from kwargs
+        inputs = self._extract_inputs(spec.inputs, args, kwargs)
+
+        # Validate domain
+        if spec.domain:
+            if not self._validate_domain(inputs, spec.domain):
+                return self._fallback(
+                    original_func, args, kwargs, spec, reason="outside_domain"
+                )
+
+        # Query emulator
+        prediction = emulator.predict(inputs)
+
+        # Check confidence
+        if prediction.confidence < threshold:
+            return self._fallback(
+                original_func,
+                args,
+                kwargs,
+                spec,
+                reason=f"low_confidence ({prediction.confidence:.3f} < {threshold})",
+            )
+
+        # Check uncertainty requirement
+        if spec.uncertainty == "required" and prediction.uncertainty_bounds is None:
+            return self._fallback(
+                original_func,
+                args,
+                kwargs,
+                spec,
+                reason="uncertainty_required_but_not_provided",
+            )
+
+        # Accept emulated result
+        dispatch_result = EmulatorDispatchResult(
+            result=prediction.outputs,
+            source="emulator",
+            confidence=prediction.confidence,
+            emulator_version=emulator.metadata.version,
+            fallback_reason=None,
+        )
+        self._record(dispatch_result)
+        return dispatch_result
+
+    def _fallback(
+        self,
+        func: Callable,
+        args: tuple,
+        kwargs: dict,
+        spec: Any,
+        *,
+        reason: str,
+    ) -> EmulatorDispatchResult:
+        """Execute fallback strategy based on spec."""
+        if spec.fallback == "error":
+            raise RuntimeError(
+                f"Emulation failed for {spec.function_name}: {reason}. "
+                f"Fallback strategy is 'error'."
+            )
+        elif spec.fallback == "cached":
+            # For now, fall through to full model (cache integration TBD)
+            pass
+
+        # Default: full_model
+        result = func(*args, **kwargs)
+        dispatch_result = EmulatorDispatchResult(
+            result=result,
+            source="full_model",
+            confidence=None,
+            emulator_version=None,
+            fallback_reason=reason,
+        )
+        self._record(dispatch_result)
+        return dispatch_result
+
+    def _extract_inputs(
+        self,
+        input_names: list[str],
+        args: tuple,
+        kwargs: dict,
+    ) -> dict[str, Any]:
+        """Extract named inputs from function arguments."""
+        inputs: dict[str, Any] = {}
+
+        # First try kwargs
+        for name in input_names:
+            if name in kwargs:
+                inputs[name] = kwargs[name]
+
+        # If first arg is a dict (common pattern), try extracting from it
+        if args and isinstance(args[0], dict):
+            for name in input_names:
+                if name not in inputs and name in args[0]:
+                    inputs[name] = args[0][name]
+
+        return inputs
+
+    def _validate_domain(
+        self,
+        inputs: dict[str, Any],
+        domain: dict[str, tuple[float, float]],
+    ) -> bool:
+        """Check if inputs are within declared domain bounds."""
+        for key, (lower, upper) in domain.items():
+            if key in inputs:
+                value = inputs[key]
+                if isinstance(value, (int, float)):
+                    if value < lower or value > upper:
+                        return False
+        return True
+
+    def _record(self, result: EmulatorDispatchResult) -> None:
+        """Record dispatch decision for telemetry."""
+        if self._record_provenance:
+            self._dispatch_log.append(result)
+
+
+__all__ = ["EmulatorDispatch", "EmulatorDispatchResult"]

--- a/scalable/emulation/registry.py
+++ b/scalable/emulation/registry.py
@@ -1,0 +1,335 @@
+"""Emulator registry for managing trained surrogate models."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from scalable.emulation.surrogate import TrainedEmulator
+
+
+@dataclass(frozen=True)
+class EmulatorInfo:
+    """Summary information about a registered emulator."""
+
+    name: str
+    version: str
+    model_type: str
+    training_samples: int
+    validation_score: float
+    input_names: list[str]
+    output_names: list[str]
+    domain_bounds: dict[str, tuple[float, float]]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "version": self.version,
+            "model_type": self.model_type,
+            "training_samples": self.training_samples,
+            "validation_score": self.validation_score,
+            "input_names": self.input_names,
+            "output_names": self.output_names,
+            "domain_bounds": self.domain_bounds,
+        }
+
+
+class EmulatorRegistry:
+    """Manages trained emulator models with versioning and domain validation.
+
+    Emulators are stored in a directory structure:
+
+    .. code-block:: text
+
+        <registry_dir>/
+          <name>/
+            <version>/
+              metadata.json
+              model.joblib (or other serialization)
+
+    Parameters
+    ----------
+    registry_dir
+        Path to the emulator registry directory.
+    """
+
+    def __init__(self, registry_dir: str | Path) -> None:
+        self._registry_dir = Path(registry_dir)
+        self._emulators: dict[str, dict[str, TrainedEmulator]] = {}
+        self._load_metadata()
+
+    def _load_metadata(self) -> None:
+        """Discover registered emulators from the filesystem."""
+        if not self._registry_dir.exists():
+            return
+        for name_dir in self._registry_dir.iterdir():
+            if not name_dir.is_dir():
+                continue
+            name = name_dir.name
+            for version_dir in name_dir.iterdir():
+                if not version_dir.is_dir():
+                    continue
+                meta_file = version_dir / "metadata.json"
+                if meta_file.exists():
+                    if name not in self._emulators:
+                        self._emulators[name] = {}
+                    # Metadata loaded lazily; actual model loaded on get()
+
+    def register(
+        self,
+        name: str,
+        emulator: TrainedEmulator,
+        *,
+        version: str | None = None,
+        domain: dict[str, tuple[float, float]] | None = None,
+    ) -> str:
+        """Register a trained emulator in the registry.
+
+        Parameters
+        ----------
+        name
+            Logical name for the emulator (e.g., "gcam_emissions").
+        emulator
+            A trained emulator implementing the :class:`TrainedEmulator` protocol.
+        version
+            Version string. If ``None``, auto-increments from latest.
+        domain
+            Optional domain bounds override (defaults to emulator metadata).
+
+        Returns
+        -------
+        str
+            The version string assigned to this registration.
+        """
+        if version is None:
+            existing_versions = list(self._emulators.get(name, {}).keys())
+            if existing_versions:
+                # Simple integer versioning
+                max_v = max(int(v) for v in existing_versions if v.isdigit())
+                version = str(max_v + 1)
+            else:
+                version = "1"
+
+        # Store in memory
+        if name not in self._emulators:
+            self._emulators[name] = {}
+        self._emulators[name][version] = emulator
+
+        # Persist metadata
+        meta = emulator.metadata
+        version_dir = self._registry_dir / name / version
+        version_dir.mkdir(parents=True, exist_ok=True)
+
+        meta_dict = meta.to_dict()
+        if domain:
+            meta_dict["domain_bounds"] = {
+                k: list(v) for k, v in domain.items()
+            }
+
+        (version_dir / "metadata.json").write_text(
+            json.dumps(meta_dict, indent=2, default=str)
+        )
+
+        # Try to persist the model itself
+        try:
+            import joblib
+
+            joblib.dump(emulator, version_dir / "model.joblib")
+        except (ImportError, Exception):
+            pass  # Model not serializable or joblib unavailable
+
+        return version
+
+    def get(
+        self,
+        name: str,
+        *,
+        version: str | None = None,
+    ) -> TrainedEmulator:
+        """Retrieve a registered emulator by name and optional version.
+
+        Parameters
+        ----------
+        name
+            Emulator name.
+        version
+            Specific version to retrieve. If ``None``, returns latest.
+
+        Returns
+        -------
+        TrainedEmulator
+            The registered emulator instance.
+
+        Raises
+        ------
+        KeyError
+            If the emulator or version is not found.
+        """
+        if name not in self._emulators or not self._emulators[name]:
+            # Try loading from disk
+            self._load_emulator_from_disk(name, version)
+
+        if name not in self._emulators or not self._emulators[name]:
+            raise KeyError(f"Emulator {name!r} not found in registry")
+
+        versions = self._emulators[name]
+        if version is not None:
+            if version not in versions:
+                raise KeyError(f"Emulator {name!r} version {version!r} not found")
+            return versions[version]
+
+        # Return latest version
+        latest = max(versions.keys(), key=lambda v: int(v) if v.isdigit() else 0)
+        return versions[latest]
+
+    def _load_emulator_from_disk(self, name: str, version: str | None) -> None:
+        """Attempt to load an emulator from disk."""
+        name_dir = self._registry_dir / name
+        if not name_dir.exists():
+            return
+
+        for version_dir in name_dir.iterdir():
+            if not version_dir.is_dir():
+                continue
+            if version is not None and version_dir.name != version:
+                continue
+
+            model_path = version_dir / "model.joblib"
+            if model_path.exists():
+                try:
+                    import joblib
+
+                    emulator = joblib.load(model_path)
+                    if name not in self._emulators:
+                        self._emulators[name] = {}
+                    self._emulators[name][version_dir.name] = emulator
+                except (ImportError, Exception):
+                    pass
+
+    def list(self) -> list[EmulatorInfo]:
+        """List all registered emulators with summary info."""
+        results: list[EmulatorInfo] = []
+
+        # Check in-memory emulators
+        for _name, versions in self._emulators.items():
+            for _ver, emulator in versions.items():
+                meta = emulator.metadata
+                results.append(
+                    EmulatorInfo(
+                        name=meta.name,
+                        version=meta.version,
+                        model_type=meta.model_type,
+                        training_samples=meta.training_samples,
+                        validation_score=meta.validation_score,
+                        input_names=meta.input_names,
+                        output_names=meta.output_names,
+                        domain_bounds=meta.domain_bounds,
+                    )
+                )
+
+        # Check filesystem for any not in memory
+        if self._registry_dir.exists():
+            for name_dir in self._registry_dir.iterdir():
+                if not name_dir.is_dir():
+                    continue
+                name = name_dir.name
+                for version_dir in name_dir.iterdir():
+                    if not version_dir.is_dir():
+                        continue
+                    ver = version_dir.name
+                    # Skip if already listed from memory
+                    if name in self._emulators and ver in self._emulators[name]:
+                        continue
+                    meta_file = version_dir / "metadata.json"
+                    if meta_file.exists():
+                        try:
+                            meta_dict = json.loads(meta_file.read_text())
+                            domain = {}
+                            for k, v in meta_dict.get("domain_bounds", {}).items():
+                                if isinstance(v, (list, tuple)) and len(v) == 2:
+                                    domain[k] = (float(v[0]), float(v[1]))
+                            results.append(
+                                EmulatorInfo(
+                                    name=meta_dict.get("name", name),
+                                    version=meta_dict.get("version", ver),
+                                    model_type=meta_dict.get("model_type", "unknown"),
+                                    training_samples=meta_dict.get("training_samples", 0),
+                                    validation_score=meta_dict.get("validation_score", 0.0),
+                                    input_names=meta_dict.get("input_names", []),
+                                    output_names=meta_dict.get("output_names", []),
+                                    domain_bounds=domain,
+                                )
+                            )
+                        except (json.JSONDecodeError, Exception):
+                            pass
+
+        return results
+
+    def validate_domain(self, name: str, inputs: dict[str, Any]) -> bool:
+        """Check if inputs fall within the emulator's declared domain bounds.
+
+        Parameters
+        ----------
+        name
+            Emulator name.
+        inputs
+            Input values to validate.
+
+        Returns
+        -------
+        bool
+            ``True`` if all inputs are within declared bounds (or no bounds declared).
+        """
+        try:
+            emulator = self.get(name)
+        except KeyError:
+            return False
+
+        domain = emulator.metadata.domain_bounds
+        if not domain:
+            return True  # No bounds declared — assume valid
+
+        for key, (lower, upper) in domain.items():
+            if key in inputs:
+                value = inputs[key]
+                if isinstance(value, (int, float)):
+                    if value < lower or value > upper:
+                        return False
+        return True
+
+    def remove(self, name: str, *, version: str | None = None) -> None:
+        """Remove an emulator from the registry.
+
+        Parameters
+        ----------
+        name
+            Emulator name to remove.
+        version
+            If specified, remove only this version. Otherwise remove all versions.
+        """
+        if name in self._emulators:
+            if version is not None:
+                self._emulators[name].pop(version, None)
+                if not self._emulators[name]:
+                    del self._emulators[name]
+            else:
+                del self._emulators[name]
+
+        # Clean up filesystem
+        if version is not None:
+            version_dir = self._registry_dir / name / version
+            if version_dir.exists():
+                import shutil
+
+                shutil.rmtree(version_dir)
+        else:
+            name_dir = self._registry_dir / name
+            if name_dir.exists():
+                import shutil
+
+                shutil.rmtree(name_dir)
+
+
+__all__ = ["EmulatorInfo", "EmulatorRegistry"]

--- a/scalable/emulation/surrogate.py
+++ b/scalable/emulation/surrogate.py
@@ -1,0 +1,280 @@
+"""Surrogate model abstractions for scientific model emulation."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Protocol
+
+import numpy as np
+
+
+@dataclass(frozen=True)
+class EmulatorPrediction:
+    """Prediction result with uncertainty information."""
+
+    outputs: dict[str, Any]
+    confidence: float
+    uncertainty_bounds: dict[str, tuple[float, float]] | None = None
+    is_emulated: bool = True
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "outputs": self.outputs,
+            "confidence": self.confidence,
+            "uncertainty_bounds": self.uncertainty_bounds,
+            "is_emulated": self.is_emulated,
+        }
+
+
+@dataclass(frozen=True)
+class EmulatorMetadata:
+    """Provenance and quality metadata for a trained emulator."""
+
+    name: str
+    version: str
+    training_runs: list[str]
+    training_samples: int
+    validation_score: float
+    domain_bounds: dict[str, tuple[float, float]]
+    created_at: str
+    model_type: str
+    output_names: list[str] = field(default_factory=list)
+    input_names: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "version": self.version,
+            "training_runs": self.training_runs,
+            "training_samples": self.training_samples,
+            "validation_score": self.validation_score,
+            "domain_bounds": self.domain_bounds,
+            "created_at": self.created_at,
+            "model_type": self.model_type,
+            "output_names": self.output_names,
+            "input_names": self.input_names,
+        }
+
+
+class TrainedEmulator(Protocol):
+    """Protocol for trained surrogate models."""
+
+    def predict(self, inputs: dict[str, Any]) -> EmulatorPrediction:
+        """Produce predictions with uncertainty for the given inputs."""
+        ...
+
+    def uncertainty(self, inputs: dict[str, Any]) -> float:
+        """Return scalar uncertainty estimate for the given inputs."""
+        ...
+
+    @property
+    def metadata(self) -> EmulatorMetadata:
+        """Return emulator provenance and quality metadata."""
+        ...
+
+
+class GradientBoostingEmulator:
+    """Gradient boosting-based surrogate model.
+
+    Uses sklearn's GradientBoostingRegressor for tabular scenario features.
+    Uncertainty is estimated from ensemble variance.
+    """
+
+    def __init__(
+        self,
+        *,
+        metadata: EmulatorMetadata,
+        models: dict[str, Any] | None = None,
+    ) -> None:
+        self._metadata = metadata
+        self._models: dict[str, Any] = models or {}
+        self._input_names = list(metadata.input_names)
+        self._output_names = list(metadata.output_names)
+
+    @property
+    def metadata(self) -> EmulatorMetadata:
+        return self._metadata
+
+    def train(
+        self,
+        X: Any,
+        y: dict[str, Any],
+        *,
+        n_estimators: int = 100,
+        max_depth: int = 5,
+        random_state: int = 42,
+    ) -> None:
+        """Train the emulator on input/output data.
+
+        Parameters
+        ----------
+        X
+            Input features (numpy array or DataFrame).
+        y
+            Dict mapping output name to target arrays.
+        """
+        try:
+            from sklearn.ensemble import GradientBoostingRegressor
+
+            for output_name, y_vals in y.items():
+                model = GradientBoostingRegressor(
+                    n_estimators=n_estimators,
+                    max_depth=max_depth,
+                    random_state=random_state,
+                )
+                model.fit(X, y_vals)
+                self._models[output_name] = model
+        except ImportError:
+            pass
+
+    def predict(self, inputs: dict[str, Any]) -> EmulatorPrediction:
+        """Predict outputs with uncertainty estimation."""
+        if not self._models:
+            return EmulatorPrediction(
+                outputs={},
+                confidence=0.0,
+                uncertainty_bounds=None,
+                is_emulated=True,
+            )
+
+        # Build input vector
+        X = np.array([[inputs.get(name, 0) for name in self._input_names]])
+
+        outputs: dict[str, Any] = {}
+        bounds: dict[str, tuple[float, float]] = {}
+        confidences: list[float] = []
+
+        for output_name, model in self._models.items():
+            pred = float(model.predict(X)[0])
+            outputs[output_name] = pred
+
+            # Estimate uncertainty from staged predictions variance
+            if hasattr(model, "estimators_"):
+                staged_preds = np.array(
+                    [est[0].predict(X)[0] for est in model.estimators_]
+                )
+                std = float(np.std(staged_preds))
+                lower = pred - 2 * std
+                upper = pred + 2 * std
+                bounds[output_name] = (lower, upper)
+                # Confidence inversely proportional to relative uncertainty
+                rel_uncertainty = std / (abs(pred) + 1e-10)
+                conf = max(0.0, min(1.0, 1.0 - rel_uncertainty))
+                confidences.append(conf)
+            else:
+                bounds[output_name] = (pred * 0.8, pred * 1.2)
+                confidences.append(0.7)
+
+        overall_confidence = float(np.mean(confidences)) if confidences else 0.5
+
+        return EmulatorPrediction(
+            outputs=outputs,
+            confidence=overall_confidence,
+            uncertainty_bounds=bounds,
+            is_emulated=True,
+        )
+
+    def uncertainty(self, inputs: dict[str, Any]) -> float:
+        """Return scalar uncertainty (1 - confidence)."""
+        pred = self.predict(inputs)
+        return 1.0 - pred.confidence
+
+
+class RandomForestEmulator:
+    """Random forest-based surrogate model.
+
+    Uses sklearn's RandomForestRegressor. Uncertainty estimated from
+    individual tree prediction variance.
+    """
+
+    def __init__(
+        self,
+        *,
+        metadata: EmulatorMetadata,
+        models: dict[str, Any] | None = None,
+    ) -> None:
+        self._metadata = metadata
+        self._models: dict[str, Any] = models or {}
+        self._input_names = list(metadata.input_names)
+        self._output_names = list(metadata.output_names)
+
+    @property
+    def metadata(self) -> EmulatorMetadata:
+        return self._metadata
+
+    def train(
+        self,
+        X: Any,
+        y: dict[str, Any],
+        *,
+        n_estimators: int = 100,
+        max_depth: int = 10,
+        random_state: int = 42,
+    ) -> None:
+        """Train the emulator on input/output data."""
+        try:
+            from sklearn.ensemble import RandomForestRegressor
+
+            for output_name, y_vals in y.items():
+                model = RandomForestRegressor(
+                    n_estimators=n_estimators,
+                    max_depth=max_depth,
+                    random_state=random_state,
+                    n_jobs=-1,
+                )
+                model.fit(X, y_vals)
+                self._models[output_name] = model
+        except ImportError:
+            pass
+
+    def predict(self, inputs: dict[str, Any]) -> EmulatorPrediction:
+        """Predict outputs with tree-based uncertainty estimation."""
+        if not self._models:
+            return EmulatorPrediction(
+                outputs={},
+                confidence=0.0,
+                uncertainty_bounds=None,
+                is_emulated=True,
+            )
+
+        X = np.array([[inputs.get(name, 0) for name in self._input_names]])
+
+        outputs: dict[str, Any] = {}
+        bounds: dict[str, tuple[float, float]] = {}
+        confidences: list[float] = []
+
+        for output_name, model in self._models.items():
+            # Get individual tree predictions
+            tree_preds = np.array([t.predict(X)[0] for t in model.estimators_])
+            pred = float(np.mean(tree_preds))
+            std = float(np.std(tree_preds))
+
+            outputs[output_name] = pred
+            bounds[output_name] = (pred - 2 * std, pred + 2 * std)
+
+            rel_uncertainty = std / (abs(pred) + 1e-10)
+            conf = max(0.0, min(1.0, 1.0 - rel_uncertainty))
+            confidences.append(conf)
+
+        overall_confidence = float(np.mean(confidences)) if confidences else 0.5
+
+        return EmulatorPrediction(
+            outputs=outputs,
+            confidence=overall_confidence,
+            uncertainty_bounds=bounds,
+            is_emulated=True,
+        )
+
+    def uncertainty(self, inputs: dict[str, Any]) -> float:
+        """Return scalar uncertainty (1 - confidence)."""
+        pred = self.predict(inputs)
+        return 1.0 - pred.confidence
+
+
+__all__ = [
+    "EmulatorMetadata",
+    "EmulatorPrediction",
+    "GradientBoostingEmulator",
+    "RandomForestEmulator",
+    "TrainedEmulator",
+]

--- a/scalable/emulation/uncertainty.py
+++ b/scalable/emulation/uncertainty.py
@@ -1,0 +1,193 @@
+"""Uncertainty calibration utilities for emulators."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import numpy as np
+
+
+@dataclass(frozen=True)
+class CalibrationResult:
+    """Result of emulator uncertainty calibration assessment."""
+
+    coverage_90: float  # Fraction of true values within 90% interval
+    coverage_95: float  # Fraction of true values within 95% interval
+    mean_interval_width: float
+    sharpness: float  # Average interval width relative to prediction magnitude
+    n_samples: int
+    is_calibrated: bool  # True if coverage is within acceptable range
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "coverage_90": self.coverage_90,
+            "coverage_95": self.coverage_95,
+            "mean_interval_width": self.mean_interval_width,
+            "sharpness": self.sharpness,
+            "n_samples": self.n_samples,
+            "is_calibrated": self.is_calibrated,
+        }
+
+
+def calibrate_emulator(
+    predictions: list[dict[str, Any]],
+    actuals: list[dict[str, Any]],
+    *,
+    output_name: str,
+    tolerance: float = 0.1,
+) -> CalibrationResult:
+    """Assess calibration of emulator uncertainty estimates.
+
+    Checks whether the stated confidence intervals actually contain
+    the true values at the stated rate.
+
+    Parameters
+    ----------
+    predictions
+        List of emulator prediction dicts (from ``EmulatorPrediction.to_dict()``).
+        Each should have ``outputs`` and ``uncertainty_bounds``.
+    actuals
+        List of actual output dicts from full-model runs.
+        Each should have the ``output_name`` key with the true value.
+    output_name
+        Which output variable to assess calibration for.
+    tolerance
+        Acceptable deviation from nominal coverage (e.g., 0.1 means
+        90% coverage for a 95% interval is acceptable).
+
+    Returns
+    -------
+    CalibrationResult
+        Calibration assessment with coverage and sharpness metrics.
+    """
+    if not predictions or not actuals or len(predictions) != len(actuals):
+        return CalibrationResult(
+            coverage_90=0.0,
+            coverage_95=0.0,
+            mean_interval_width=0.0,
+            sharpness=0.0,
+            n_samples=0,
+            is_calibrated=False,
+        )
+
+    in_90: list[bool] = []
+    in_95: list[bool] = []
+    widths: list[float] = []
+    relative_widths: list[float] = []
+
+    for pred, actual in zip(predictions, actuals, strict=False):
+        true_value = actual.get(output_name)
+        if true_value is None:
+            continue
+
+        true_value = float(true_value)
+        outputs = pred.get("outputs", {})
+        bounds = pred.get("uncertainty_bounds", {})
+
+        if output_name not in bounds:
+            continue
+
+        bound = bounds[output_name]
+        if not isinstance(bound, (list, tuple)) or len(bound) != 2:
+            continue
+
+        lower, upper = float(bound[0]), float(bound[1])
+        width = upper - lower
+        widths.append(width)
+
+        pred_value = float(outputs.get(output_name, 0))
+        mag = abs(pred_value) + 1e-10
+        relative_widths.append(width / mag)
+
+        # 95% interval check (using full bounds)
+        in_95.append(lower <= true_value <= upper)
+
+        # 90% interval (shrink bounds by ~5% on each side)
+        shrink = width * 0.05
+        in_90.append((lower + shrink) <= true_value <= (upper - shrink))
+
+    n = len(in_95)
+    if n == 0:
+        return CalibrationResult(
+            coverage_90=0.0,
+            coverage_95=0.0,
+            mean_interval_width=0.0,
+            sharpness=0.0,
+            n_samples=0,
+            is_calibrated=False,
+        )
+
+    coverage_90 = float(np.mean(in_90))
+    coverage_95 = float(np.mean(in_95))
+    mean_width = float(np.mean(widths))
+    sharpness = float(np.mean(relative_widths))
+
+    # Check if calibration is acceptable
+    # For 95% intervals, coverage should be at least 95% - tolerance
+    is_calibrated = coverage_95 >= (0.95 - tolerance)
+
+    return CalibrationResult(
+        coverage_90=coverage_90,
+        coverage_95=coverage_95,
+        mean_interval_width=mean_width,
+        sharpness=sharpness,
+        n_samples=n,
+        is_calibrated=is_calibrated,
+    )
+
+
+def compute_confidence_from_uncertainty(
+    uncertainty: float,
+    *,
+    max_uncertainty: float = 1.0,
+) -> float:
+    """Convert a scalar uncertainty value to a confidence score.
+
+    Parameters
+    ----------
+    uncertainty
+        Raw uncertainty value (higher = less confident).
+    max_uncertainty
+        Maximum expected uncertainty for normalization.
+
+    Returns
+    -------
+    float
+        Confidence in [0, 1] range (higher = more confident).
+    """
+    if uncertainty <= 0:
+        return 1.0
+    if uncertainty >= max_uncertainty:
+        return 0.0
+    return 1.0 - (uncertainty / max_uncertainty)
+
+
+def is_in_domain(
+    inputs: dict[str, Any],
+    domain_bounds: dict[str, tuple[float, float]],
+) -> bool:
+    """Check if all inputs are within declared domain bounds.
+
+    Parameters
+    ----------
+    inputs
+        Input values to check.
+    domain_bounds
+        Dict mapping input names to (min, max) tuples.
+
+    Returns
+    -------
+    bool
+        ``True`` if all specified inputs are within bounds.
+    """
+    for key, (lower, upper) in domain_bounds.items():
+        if key in inputs:
+            value = inputs[key]
+            if isinstance(value, (int, float)):
+                if value < lower or value > upper:
+                    return False
+    return True
+
+
+__all__ = ["CalibrationResult", "calibrate_emulator", "compute_confidence_from_uncertainty", "is_in_domain"]

--- a/scalable/ml/__init__.py
+++ b/scalable/ml/__init__.py
@@ -1,0 +1,34 @@
+"""ML optimization subsystem for Scalable (Phase 5).
+
+This package provides machine-learning-backed resource prediction, adaptive
+scaling, and distributed hyperparameter tuning. All features degrade gracefully
+to Phase 2 heuristics when ``scalable[ml]`` is not installed.
+
+Key components:
+
+* :class:`LearnedAdvisor` — ML-based resource recommendations
+* :class:`AdaptiveScaler` — real-time adaptive worker scaling
+* :class:`HyperparameterSearch` — Dask-ML distributed tuning
+* :class:`FeatureExtractor` — telemetry feature engineering
+"""
+
+from __future__ import annotations
+
+from .adaptive_scaler import AdaptiveScaler, ScaleDecision
+from .features import FeatureExtractor
+from .learned_advisor import LearnedAdvisor
+from .models import ModelQuality, PredictionResult
+from .tuning import HyperparameterSearch, TuningResult
+from .validation import cross_validate_advisor
+
+__all__ = [
+    "AdaptiveScaler",
+    "FeatureExtractor",
+    "HyperparameterSearch",
+    "LearnedAdvisor",
+    "ModelQuality",
+    "PredictionResult",
+    "ScaleDecision",
+    "TuningResult",
+    "cross_validate_advisor",
+]

--- a/scalable/ml/adaptive_scaler.py
+++ b/scalable/ml/adaptive_scaler.py
@@ -1,0 +1,243 @@
+"""Real-time adaptive worker scaling based on ML predictions."""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass(frozen=True)
+class ScaleDecision:
+    """A scaling recommendation with reasoning."""
+
+    workers_to_add: dict[str, int]
+    workers_to_remove: dict[str, int]
+    reasoning: str
+    confidence: float
+    predicted_completion_time: float | None = None
+    timestamp: float = field(default_factory=time.time)
+
+    @property
+    def has_changes(self) -> bool:
+        """Whether this decision suggests any scaling changes."""
+        return bool(self.workers_to_add or self.workers_to_remove)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "workers_to_add": dict(self.workers_to_add),
+            "workers_to_remove": dict(self.workers_to_remove),
+            "reasoning": self.reasoning,
+            "confidence": self.confidence,
+            "predicted_completion_time": self.predicted_completion_time,
+            "timestamp": self.timestamp,
+        }
+
+
+class AdaptiveScaler:
+    """Real-time adaptive worker scaling based on ML predictions.
+
+    Monitors task queue depth and active worker utilization to recommend
+    scaling actions. Respects user-defined min/max bounds and cooldown
+    periods to prevent thrashing.
+
+    Parameters
+    ----------
+    advisor
+        A :class:`~scalable.ml.learned_advisor.LearnedAdvisor` or
+        :class:`~scalable.advising.resources.ResourceAdvisor` instance
+        for predicting task durations.
+    min_workers
+        Minimum worker count per tag (floor).
+    max_workers
+        Maximum worker count per tag (ceiling).
+    scale_up_threshold
+        Queue depth ratio that triggers scale-up (0.0–1.0).
+    scale_down_threshold
+        Queue depth ratio that triggers scale-down (0.0–1.0).
+    cooldown_seconds
+        Minimum time between scaling decisions.
+    """
+
+    def __init__(
+        self,
+        *,
+        advisor: Any = None,
+        min_workers: dict[str, int] | None = None,
+        max_workers: dict[str, int] | None = None,
+        scale_up_threshold: float = 0.8,
+        scale_down_threshold: float = 0.2,
+        cooldown_seconds: float = 60.0,
+    ) -> None:
+        self._advisor = advisor
+        self._min_workers = min_workers or {}
+        self._max_workers = max_workers or {}
+        self._scale_up_threshold = scale_up_threshold
+        self._scale_down_threshold = scale_down_threshold
+        self._cooldown_seconds = cooldown_seconds
+        self._last_decision_time: float = 0.0
+        self._decision_history: list[ScaleDecision] = []
+
+    @property
+    def decision_history(self) -> list[ScaleDecision]:
+        """List of all scaling decisions made."""
+        return list(self._decision_history)
+
+    def evaluate(
+        self,
+        *,
+        pending_tasks: list[dict[str, Any]],
+        active_workers: dict[str, int],
+        recent_completions: list[dict[str, Any]] | None = None,
+    ) -> ScaleDecision:
+        """Evaluate current state and recommend scaling actions.
+
+        Parameters
+        ----------
+        pending_tasks
+            List of pending task metadata dicts. Each should have at least
+            ``tag`` or ``component`` key.
+        active_workers
+            Current worker count per tag/component.
+        recent_completions
+            Recently completed task metadata for throughput estimation.
+
+        Returns
+        -------
+        ScaleDecision
+            Recommended scaling action with reasoning.
+        """
+        now = time.time()
+
+        # Check cooldown
+        if now - self._last_decision_time < self._cooldown_seconds:
+            return ScaleDecision(
+                workers_to_add={},
+                workers_to_remove={},
+                reasoning="Cooldown period active",
+                confidence=1.0,
+                predicted_completion_time=None,
+            )
+
+        # Group pending tasks by tag/component
+        pending_by_tag: dict[str, int] = {}
+        for task in pending_tasks:
+            tag = task.get("tag") or task.get("component") or "default"
+            pending_by_tag[tag] = pending_by_tag.get(tag, 0) + 1
+
+        workers_to_add: dict[str, int] = {}
+        workers_to_remove: dict[str, int] = {}
+        reasons: list[str] = []
+
+        for tag, pending_count in pending_by_tag.items():
+            current_workers = active_workers.get(tag, 0)
+            max_allowed = self._max_workers.get(tag, current_workers + 10)
+            min_allowed = self._min_workers.get(tag, 0)
+
+            if current_workers == 0:
+                # No workers — always scale up if there's pending work
+                to_add = min(pending_count, max_allowed)
+                if to_add > 0:
+                    workers_to_add[tag] = to_add
+                    reasons.append(f"{tag}: no workers, adding {to_add} for {pending_count} pending")
+                continue
+
+            # Calculate queue ratio (pending per worker)
+            queue_ratio = pending_count / max(current_workers, 1)
+
+            if queue_ratio > self._scale_up_threshold:
+                # Scale up: add workers proportional to excess queue
+                desired = min(
+                    int(pending_count / self._scale_up_threshold),
+                    max_allowed,
+                )
+                to_add = max(0, desired - current_workers)
+                if to_add > 0:
+                    workers_to_add[tag] = to_add
+                    reasons.append(
+                        f"{tag}: queue ratio {queue_ratio:.2f} > {self._scale_up_threshold}, "
+                        f"adding {to_add} workers"
+                    )
+
+            elif queue_ratio < self._scale_down_threshold and current_workers > min_allowed:
+                # Scale down: remove excess workers
+                desired = max(
+                    int(pending_count / self._scale_up_threshold) + 1,
+                    min_allowed,
+                )
+                to_remove = max(0, current_workers - desired)
+                if to_remove > 0:
+                    workers_to_remove[tag] = to_remove
+                    reasons.append(
+                        f"{tag}: queue ratio {queue_ratio:.2f} < {self._scale_down_threshold}, "
+                        f"removing {to_remove} workers"
+                    )
+
+        # Check for tags with workers but no pending tasks
+        for tag, count in active_workers.items():
+            if tag not in pending_by_tag and count > self._min_workers.get(tag, 0):
+                excess = count - self._min_workers.get(tag, 0)
+                if excess > 0:
+                    workers_to_remove[tag] = excess
+                    reasons.append(f"{tag}: no pending tasks, removing {excess} idle workers")
+
+        # Estimate completion time
+        predicted_completion = self._estimate_completion_time(
+            pending_by_tag, active_workers, workers_to_add, recent_completions
+        )
+
+        reasoning = "; ".join(reasons) if reasons else "No scaling changes needed"
+        confidence = 0.9 if self._advisor is not None else 0.7
+
+        decision = ScaleDecision(
+            workers_to_add=workers_to_add,
+            workers_to_remove=workers_to_remove,
+            reasoning=reasoning,
+            confidence=confidence,
+            predicted_completion_time=predicted_completion,
+        )
+
+        self._last_decision_time = now
+        self._decision_history.append(decision)
+        return decision
+
+    def _estimate_completion_time(
+        self,
+        pending_by_tag: dict[str, int],
+        active_workers: dict[str, int],
+        workers_to_add: dict[str, int],
+        recent_completions: list[dict[str, Any]] | None,
+    ) -> float | None:
+        """Estimate time to complete all pending tasks."""
+        if not pending_by_tag:
+            return 0.0
+
+        if not recent_completions:
+            return None
+
+        # Simple throughput-based estimation
+        total_pending = sum(pending_by_tag.values())
+        total_workers = sum(active_workers.values()) + sum(workers_to_add.values())
+
+        if total_workers == 0:
+            return None
+
+        # Estimate average task duration from recent completions
+        durations = [
+            c.get("duration_s", 60)
+            for c in recent_completions
+            if c.get("duration_s") is not None
+        ]
+        if not durations:
+            return None
+
+        avg_duration = sum(durations) / len(durations)
+        estimated_time = (total_pending / total_workers) * avg_duration
+        return estimated_time
+
+    def reset_cooldown(self) -> None:
+        """Reset the cooldown timer (for testing or manual override)."""
+        self._last_decision_time = 0.0
+
+
+__all__ = ["AdaptiveScaler", "ScaleDecision"]

--- a/scalable/ml/features.py
+++ b/scalable/ml/features.py
@@ -1,0 +1,197 @@
+"""Feature extraction from telemetry records and task arguments."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+import numpy as np
+import pandas as pd
+
+
+@dataclass
+class FeatureExtractor:
+    """Extract ML features from telemetry records and task arguments.
+
+    Engineered features include:
+    - Task identity (component name hash, tag hash)
+    - Resource request features (requested cpus/memory/walltime)
+    - Temporal features (hour of day, day of week)
+    - Historical aggregates (rolling mean/p95 for same task)
+    - Input complexity features (from user-provided input_features dict)
+    """
+
+    #: Minimum rows per task group for rolling aggregates
+    min_group_size: int = 3
+
+    #: Known numeric input feature names (auto-discovered if not set)
+    known_input_features: list[str] = field(default_factory=list)
+
+    def extract_from_history(self, records: pd.DataFrame) -> pd.DataFrame:
+        """Engineer features from historical telemetry records.
+
+        Parameters
+        ----------
+        records
+            DataFrame from :class:`~scalable.advising.resources.ResourceAdvisor`
+            internal format: columns include ``task_name``, ``component``,
+            ``duration_s``, ``requested_cpus``, ``requested_memory_bytes``, etc.
+
+        Returns
+        -------
+        pd.DataFrame
+            Feature matrix suitable for ML model training with target columns
+            preserved (``duration_s``, ``requested_memory_bytes``).
+        """
+        if records.empty:
+            return pd.DataFrame()
+
+        df = records.copy()
+
+        # Task identity features (hashed for model consumption)
+        df["task_name_hash"] = df["task_name"].apply(
+            lambda x: hash(str(x)) % 10000 if pd.notna(x) else 0
+        )
+        df["component_hash"] = df["component"].apply(
+            lambda x: hash(str(x)) % 10000 if pd.notna(x) else 0
+        )
+
+        # Numeric resource features
+        df["requested_cpus_num"] = pd.to_numeric(
+            df.get("requested_cpus"), errors="coerce"
+        ).fillna(1)
+        df["requested_memory_num"] = pd.to_numeric(
+            df.get("requested_memory_bytes"), errors="coerce"
+        ).fillna(0)
+        df["requested_workers_num"] = pd.to_numeric(
+            df.get("requested_workers"), errors="coerce"
+        ).fillna(1)
+
+        # Duration target (kept for training, not used as input feature)
+        df["duration_num"] = pd.to_numeric(
+            df.get("duration_s"), errors="coerce"
+        )
+
+        # Historical rolling aggregates per task_name
+        df = df.sort_index()
+        grouped = df.groupby("task_name", sort=False)
+        df["hist_mean_duration"] = grouped["duration_num"].transform(
+            lambda s: s.expanding(min_periods=1).mean().shift(1)
+        )
+        df["hist_p95_duration"] = grouped["duration_num"].transform(
+            lambda s: s.expanding(min_periods=1).quantile(0.95).shift(1)
+        )
+        df["hist_mean_memory"] = grouped["requested_memory_num"].transform(
+            lambda s: s.expanding(min_periods=1).mean().shift(1)
+        )
+        df["hist_count"] = grouped["duration_num"].transform(
+            lambda s: s.expanding(min_periods=1).count().shift(1)
+        )
+
+        # Fill NaN from rolling aggregates with global means
+        for col in ["hist_mean_duration", "hist_p95_duration", "hist_mean_memory", "hist_count"]:
+            df[col] = df[col].fillna(0)
+
+        feature_cols = [
+            "task_name_hash",
+            "component_hash",
+            "requested_cpus_num",
+            "requested_memory_num",
+            "requested_workers_num",
+            "hist_mean_duration",
+            "hist_p95_duration",
+            "hist_mean_memory",
+            "hist_count",
+        ]
+
+        # Keep targets for training
+        target_cols = ["duration_num", "requested_memory_num"]
+        available_targets = [c for c in target_cols if c in df.columns]
+
+        return df[feature_cols + available_targets].copy()
+
+    def extract_from_task(
+        self,
+        task_name: str,
+        input_features: dict[str, Any] | None,
+        component: str | None,
+        target: str | None,
+        *,
+        history_stats: dict[str, Any] | None = None,
+    ) -> pd.DataFrame:
+        """Build feature vector for a new prediction request.
+
+        Parameters
+        ----------
+        task_name
+            Name of the task to predict for.
+        input_features
+            User-provided features (scenario count, input size, etc.).
+        component
+            Component name associated with the task.
+        target
+            Deployment target name.
+        history_stats
+            Pre-computed rolling stats from history (mean_duration, p95, count).
+
+        Returns
+        -------
+        pd.DataFrame
+            Single-row feature DataFrame for model prediction.
+        """
+        stats = history_stats or {}
+        row: dict[str, Any] = {
+            "task_name_hash": hash(str(task_name)) % 10000,
+            "component_hash": hash(str(component)) % 10000 if component else 0,
+            "requested_cpus_num": 1,
+            "requested_memory_num": 0,
+            "requested_workers_num": 1,
+            "hist_mean_duration": stats.get("mean_duration", 0),
+            "hist_p95_duration": stats.get("p95_duration", 0),
+            "hist_mean_memory": stats.get("mean_memory", 0),
+            "hist_count": stats.get("count", 0),
+        }
+
+        # Incorporate user-provided numeric input features
+        if input_features:
+            for key, value in input_features.items():
+                if isinstance(value, (int, float)) and not isinstance(value, bool):
+                    col_name = f"input_{key}"
+                    row[col_name] = value
+
+        return pd.DataFrame([row])
+
+    def compute_history_stats(
+        self,
+        records: pd.DataFrame,
+        task_name: str,
+        target: str | None = None,
+    ) -> dict[str, Any]:
+        """Compute summary statistics for a task from historical records.
+
+        These can be passed to :meth:`extract_from_task` as ``history_stats``.
+        """
+        if records.empty:
+            return {"mean_duration": 0, "p95_duration": 0, "mean_memory": 0, "count": 0}
+
+        scoped = records[records["task_name"] == task_name]
+        if target is not None and not scoped.empty:
+            scoped_target = scoped[scoped.get("target") == target]
+            if not scoped_target.empty:
+                scoped = scoped_target
+
+        if scoped.empty:
+            return {"mean_duration": 0, "p95_duration": 0, "mean_memory": 0, "count": 0}
+
+        duration = pd.to_numeric(scoped.get("duration_s"), errors="coerce").dropna()
+        memory = pd.to_numeric(scoped.get("requested_memory_bytes"), errors="coerce").dropna()
+
+        return {
+            "mean_duration": float(duration.mean()) if not duration.empty else 0,
+            "p95_duration": float(np.percentile(duration, 95)) if not duration.empty else 0,
+            "mean_memory": float(memory.mean()) if not memory.empty else 0,
+            "count": int(len(scoped)),
+        }
+
+
+__all__ = ["FeatureExtractor"]

--- a/scalable/ml/learned_advisor.py
+++ b/scalable/ml/learned_advisor.py
@@ -1,0 +1,415 @@
+"""ML-backed resource advisor using telemetry history as training data."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+from dask.utils import parse_bytes
+
+from scalable.advising.resources import (
+    ResourceRecommendation,
+    _bytes_to_gib_string,
+    _seconds_to_hhmmss,
+)
+from scalable.ml.features import FeatureExtractor
+from scalable.ml.models import ResourceModel
+from scalable.telemetry.collectors import iter_run_dirs, read_jsonl
+
+
+def _memory_to_bytes(value: str | None) -> int | None:
+    if value is None:
+        return None
+    try:
+        parsed = int(parse_bytes(value))
+    except Exception:
+        return None
+    return parsed if parsed > 0 else None
+
+
+class LearnedAdvisor:
+    """ML-backed resource advisor using telemetry history as training data.
+
+    Replaces heuristic quantile-based recommendations with feature-based
+    predictions from trained ML models. Falls back to percentile estimation
+    when insufficient data or sklearn unavailable.
+    """
+
+    #: Minimum number of records for a task before activating ML predictions
+    MIN_SAMPLES_FOR_ML: int = 10
+
+    def __init__(
+        self,
+        records: pd.DataFrame,
+        *,
+        duration_model: ResourceModel | None = None,
+        memory_model: ResourceModel | None = None,
+        extractor: FeatureExtractor | None = None,
+    ) -> None:
+        self._records = records.copy()
+        self._duration_model = duration_model
+        self._memory_model = memory_model
+        self._extractor = extractor or FeatureExtractor()
+
+    @classmethod
+    def from_history(
+        cls,
+        runs_dir: str | Path,
+        *,
+        model_type: str = "gradient_boosting",
+        retrain: bool = False,
+        cache_dir: str | Path | None = None,
+    ) -> LearnedAdvisor:
+        """Build and train advisor from telemetry run directories.
+
+        Parameters
+        ----------
+        runs_dir
+            Path to ``.scalable/runs/`` directory.
+        model_type
+            ML model type: ``gradient_boosting``, ``random_forest``, or
+            ``quantile_regression``.
+        retrain
+            Force retraining even if cached model exists.
+        cache_dir
+            Directory to cache trained models. Defaults to
+            ``<runs_dir>/../models``.
+        """
+        records = cls._load_records(runs_dir)
+        extractor = FeatureExtractor()
+
+        # Attempt to load cached models
+        if cache_dir is None:
+            cache_dir = Path(runs_dir).parent / "models"
+        cache_path = Path(cache_dir)
+
+        duration_model: ResourceModel | None = None
+        memory_model: ResourceModel | None = None
+
+        if not retrain and (cache_path / "duration" / "metadata.json").exists():
+            try:
+                duration_model = ResourceModel.load(cache_path / "duration")
+            except Exception:
+                duration_model = None
+
+        if not retrain and (cache_path / "memory" / "metadata.json").exists():
+            try:
+                memory_model = ResourceModel.load(cache_path / "memory")
+            except Exception:
+                memory_model = None
+
+        # Train if needed
+        if duration_model is None or memory_model is None:
+            features = extractor.extract_from_history(records)
+            if not features.empty and len(features) >= cls.MIN_SAMPLES_FOR_ML:
+                if duration_model is None:
+                    valid_duration = features[
+                        features["duration_num"].notna() & (features["duration_num"] > 0)
+                    ]
+                    if len(valid_duration) >= cls.MIN_SAMPLES_FOR_ML:
+                        y_dur = valid_duration["duration_num"]
+                        X_dur = valid_duration.drop(
+                            columns=["duration_num", "requested_memory_num"],
+                            errors="ignore",
+                        )
+                        duration_model = ResourceModel(
+                            model_type=model_type, random_state=42
+                        )
+                        duration_model.fit(X_dur, y_dur)
+                        try:
+                            duration_model.save(cache_path / "duration")
+                        except Exception:
+                            pass
+
+                if memory_model is None:
+                    valid_memory = features[
+                        features["requested_memory_num"].notna()
+                        & (features["requested_memory_num"] > 0)
+                    ]
+                    if len(valid_memory) >= cls.MIN_SAMPLES_FOR_ML:
+                        y_mem = valid_memory["requested_memory_num"]
+                        X_mem = valid_memory.drop(
+                            columns=["duration_num", "requested_memory_num"],
+                            errors="ignore",
+                        )
+                        memory_model = ResourceModel(
+                            model_type=model_type, random_state=42
+                        )
+                        memory_model.fit(X_mem, y_mem)
+                        try:
+                            memory_model.save(cache_path / "memory")
+                        except Exception:
+                            pass
+
+        return cls(
+            records,
+            duration_model=duration_model,
+            memory_model=memory_model,
+            extractor=extractor,
+        )
+
+    @classmethod
+    def _load_records(cls, runs_dir: str | Path) -> pd.DataFrame:
+        """Load telemetry records from run directories."""
+        rows: list[dict[str, Any]] = []
+        for run_dir in iter_run_dirs(runs_dir):
+            run_json = run_dir / "run.json"
+            if not run_json.exists():
+                continue
+            run_meta = pd.read_json(run_json, typ="series")
+            run_id = str(run_meta.get("run_id", run_dir.name))
+            target_name = run_meta.get("target_name")
+
+            task_rows = read_jsonl(run_dir / "tasks.jsonl")
+            resource_rows = read_jsonl(run_dir / "resources.jsonl")
+
+            resources_by_task: dict[str, dict[str, Any]] = {}
+            for r in resource_rows:
+                if r.get("entity_type") != "task":
+                    continue
+                entity = str(r.get("entity_id", ""))
+                if entity:
+                    resources_by_task[entity] = r
+
+            for t in task_rows:
+                if t.get("state") not in {"succeeded", "failed", "cancelled"}:
+                    continue
+                task_id = str(t.get("task_id", ""))
+                if not task_id:
+                    continue
+                resources = resources_by_task.get(task_id, {})
+                rows.append(
+                    {
+                        "run_id": run_id,
+                        "target": target_name,
+                        "task_id": task_id,
+                        "task_name": t.get("task_name"),
+                        "component": t.get("component"),
+                        "state": t.get("state"),
+                        "duration_s": t.get("duration_s"),
+                        "requested_workers": resources.get("requested_workers"),
+                        "requested_cpus": resources.get("requested_cpus"),
+                        "requested_memory": resources.get("requested_memory"),
+                        "requested_memory_bytes": _memory_to_bytes(
+                            resources.get("requested_memory")
+                        ),
+                        "requested_walltime": resources.get("requested_walltime"),
+                    }
+                )
+
+        return pd.DataFrame(rows)
+
+    def recommend(
+        self,
+        *,
+        task: str,
+        input_features: dict[str, Any] | None = None,
+        target: str | None = None,
+        confidence: float = 0.95,
+    ) -> ResourceRecommendation:
+        """Recommend resources using ML predictions with calibrated intervals.
+
+        Falls back to quantile heuristics when ML is unavailable or data is
+        insufficient for the requested task.
+        """
+        q = min(max(float(confidence), 0.5), 0.99)
+
+        # Check if we have enough data for this task
+        scoped = self._records[self._records["task_name"] == task]
+        if target is not None and not scoped.empty:
+            scoped_target = scoped[scoped["target"] == target]
+            if not scoped_target.empty:
+                scoped = scoped_target
+
+        if scoped.empty or len(scoped) < self.MIN_SAMPLES_FOR_ML:
+            # Fall back to heuristic
+            return self._heuristic_recommend(task, target, q, scoped)
+
+        # Compute history stats for feature extraction
+        stats = self._extractor.compute_history_stats(self._records, task, target)
+        X_pred = self._extractor.extract_from_task(
+            task_name=task,
+            input_features=input_features,
+            component=scoped["component"].dropna().iloc[-1] if scoped["component"].notna().any() else None,
+            target=target,
+            history_stats=stats,
+        )
+
+        # Predict duration
+        predicted_walltime: str | None = None
+        duration_evidence: dict[str, Any] = {}
+        if self._duration_model is not None and self._duration_model.is_fitted:
+            dur_preds = self._duration_model.predict(X_pred)
+            if dur_preds:
+                dur_pred = dur_preds[0]
+                # Use upper bound for safety
+                walltime_s = dur_pred.upper if dur_pred.upper else dur_pred.point * 1.2
+                predicted_walltime = _seconds_to_hhmmss(walltime_s)
+                duration_evidence = {
+                    "predicted_duration_s": dur_pred.point,
+                    "duration_lower": dur_pred.lower,
+                    "duration_upper": dur_pred.upper,
+                    "feature_importances": self._duration_model.feature_importances(),
+                }
+
+        # Predict memory
+        predicted_memory: str | None = None
+        memory_evidence: dict[str, Any] = {}
+        if self._memory_model is not None and self._memory_model.is_fitted:
+            mem_preds = self._memory_model.predict(X_pred)
+            if mem_preds:
+                mem_pred = mem_preds[0]
+                # Use upper bound for safety with 10% margin
+                memory_bytes = int((mem_pred.upper or mem_pred.point * 1.3) * 1.1)
+                predicted_memory = _bytes_to_gib_string(memory_bytes)
+                memory_evidence = {
+                    "predicted_memory_bytes": mem_pred.point,
+                    "memory_lower": mem_pred.lower,
+                    "memory_upper": mem_pred.upper,
+                }
+
+        # Component and workers from history
+        component = str(
+            scoped["component"].dropna().iloc[-1]
+            if scoped["component"].notna().any()
+            else task
+        )
+        workers_series = pd.to_numeric(scoped["requested_workers"], errors="coerce").dropna()
+        workers = int(max(1, round(float(workers_series.quantile(q))))) if not workers_series.empty else 1
+
+        cpus_series = pd.to_numeric(scoped["requested_cpus"], errors="coerce").dropna()
+        cpus = int(max(1, round(float(cpus_series.quantile(q))))) if not cpus_series.empty else 1
+
+        evidence: dict[str, Any] = {
+            "records": int(len(scoped)),
+            "method": "ml",
+            "model_type": self._duration_model.model_type if self._duration_model else "none",
+            "confidence": q,
+            "component": component,
+            **duration_evidence,
+            **memory_evidence,
+        }
+
+        return ResourceRecommendation(
+            task=task,
+            target=target,
+            confidence=q,
+            workers={component: workers},
+            resources={
+                component: {
+                    "cpus": cpus,
+                    "memory": predicted_memory,
+                    "walltime": predicted_walltime,
+                }
+            },
+            evidence=evidence,
+        )
+
+    def _heuristic_recommend(
+        self,
+        task: str,
+        target: str | None,
+        q: float,
+        scoped: pd.DataFrame,
+    ) -> ResourceRecommendation:
+        """Fallback to simple quantile heuristics (Phase 2 behavior)."""
+        if scoped.empty:
+            return ResourceRecommendation(
+                task=task,
+                target=target,
+                confidence=q,
+                workers={task: 1},
+                resources={task: {"cpus": 1, "memory": None, "walltime": None}},
+                evidence={"records": 0, "method": "heuristic", "reason": "no history"},
+            )
+
+        component = str(
+            scoped["component"].dropna().iloc[-1]
+            if scoped["component"].notna().any()
+            else task
+        )
+
+        workers_series = pd.to_numeric(scoped["requested_workers"], errors="coerce").dropna()
+        cpus_series = pd.to_numeric(scoped["requested_cpus"], errors="coerce").dropna()
+        duration_series = pd.to_numeric(scoped["duration_s"], errors="coerce").dropna()
+        mem_series = pd.to_numeric(scoped["requested_memory_bytes"], errors="coerce").dropna()
+
+        workers = int(max(1, round(float(workers_series.quantile(q))))) if not workers_series.empty else 1
+        cpus = int(max(1, round(float(cpus_series.quantile(q))))) if not cpus_series.empty else 1
+
+        memory_bytes = int(mem_series.quantile(q) * 1.10) if not mem_series.empty else None
+        walltime_s = float(duration_series.quantile(q) * 1.20) if not duration_series.empty else None
+
+        return ResourceRecommendation(
+            task=task,
+            target=target,
+            confidence=q,
+            workers={component: workers},
+            resources={
+                component: {
+                    "cpus": cpus,
+                    "memory": _bytes_to_gib_string(memory_bytes),
+                    "walltime": _seconds_to_hhmmss(walltime_s),
+                }
+            },
+            evidence={
+                "records": int(len(scoped)),
+                "method": "heuristic",
+                "reason": f"insufficient data (need {self.MIN_SAMPLES_FOR_ML})",
+                "component": component,
+            },
+        )
+
+    def explain(self, recommendation: ResourceRecommendation) -> dict[str, Any]:
+        """Return detailed explanation including feature importances."""
+        explanation: dict[str, Any] = {
+            "task": recommendation.task,
+            "target": recommendation.target,
+            "confidence": recommendation.confidence,
+            "method": recommendation.evidence.get("method", "unknown"),
+        }
+
+        if recommendation.evidence.get("method") == "ml":
+            explanation["feature_importances"] = recommendation.evidence.get(
+                "feature_importances", {}
+            )
+            explanation["prediction_intervals"] = {
+                "duration": {
+                    "point": recommendation.evidence.get("predicted_duration_s"),
+                    "lower": recommendation.evidence.get("duration_lower"),
+                    "upper": recommendation.evidence.get("duration_upper"),
+                },
+                "memory": {
+                    "point": recommendation.evidence.get("predicted_memory_bytes"),
+                    "lower": recommendation.evidence.get("memory_lower"),
+                    "upper": recommendation.evidence.get("memory_upper"),
+                },
+            }
+        else:
+            explanation["fallback_reason"] = recommendation.evidence.get("reason", "")
+
+        return explanation
+
+    def evaluate(self, *, test_fraction: float = 0.2) -> dict[str, Any]:
+        """Cross-validate models and return quality metrics."""
+        from scalable.ml.validation import cross_validate_advisor
+
+        quality_duration = cross_validate_advisor(
+            self._records,
+            model_type=self._duration_model.model_type if self._duration_model else "gradient_boosting",
+            target_column="duration_num",
+        )
+        quality_memory = cross_validate_advisor(
+            self._records,
+            model_type=self._memory_model.model_type if self._memory_model else "gradient_boosting",
+            target_column="requested_memory_num",
+        )
+
+        return {
+            "duration_model": quality_duration.to_dict(),
+            "memory_model": quality_memory.to_dict(),
+        }
+
+
+__all__ = ["LearnedAdvisor"]

--- a/scalable/ml/models.py
+++ b/scalable/ml/models.py
@@ -1,0 +1,338 @@
+"""ML model wrappers for resource prediction (Phase 5).
+
+Provides sklearn-compatible model abstractions with unified interface for
+training, prediction, and interval estimation. All sklearn imports are lazy
+so the module loads without ``scalable[ml]`` installed.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pandas as pd
+
+
+@dataclass(frozen=True)
+class PredictionResult:
+    """Prediction output with optional confidence intervals."""
+
+    point: float
+    lower: float | None = None
+    upper: float | None = None
+    confidence: float = 0.95
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "point": self.point,
+            "lower": self.lower,
+            "upper": self.upper,
+            "confidence": self.confidence,
+        }
+
+
+@dataclass(frozen=True)
+class ModelQuality:
+    """Quality metrics from cross-validation or holdout evaluation."""
+
+    mae: float
+    rmse: float
+    r2: float
+    coverage: float  # Fraction of true values within predicted intervals
+    n_samples: int
+    model_type: str
+    target_name: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "mae": self.mae,
+            "rmse": self.rmse,
+            "r2": self.r2,
+            "coverage": self.coverage,
+            "n_samples": self.n_samples,
+            "model_type": self.model_type,
+            "target_name": self.target_name,
+        }
+
+
+class ResourceModel:
+    """Unified wrapper around sklearn estimators for resource prediction.
+
+    Supports gradient boosting, random forest, and quantile regression.
+    Falls back to simple percentile estimator if sklearn is unavailable.
+    """
+
+    def __init__(
+        self,
+        model_type: str = "gradient_boosting",
+        *,
+        quantile_lower: float = 0.05,
+        quantile_upper: float = 0.95,
+        random_state: int = 42,
+    ) -> None:
+        self.model_type = model_type
+        self.quantile_lower = quantile_lower
+        self.quantile_upper = quantile_upper
+        self.random_state = random_state
+        self._model: Any = None
+        self._model_lower: Any = None
+        self._model_upper: Any = None
+        self._feature_names: list[str] = []
+        self._is_fitted = False
+        self._fallback_percentiles: dict[str, float] | None = None
+
+    @property
+    def is_fitted(self) -> bool:
+        return self._is_fitted
+
+    @property
+    def feature_names(self) -> list[str]:
+        return list(self._feature_names)
+
+    def fit(self, X: pd.DataFrame, y: pd.Series) -> ResourceModel:
+        """Train the model on feature matrix X and target y.
+
+        Parameters
+        ----------
+        X
+            Feature matrix (from :class:`FeatureExtractor`).
+        y
+            Target variable (e.g., duration_s or memory_bytes).
+
+        Returns
+        -------
+        self
+        """
+        if X.empty or len(y) < 2:
+            # Too few samples — store percentile fallback
+            self._fallback_percentiles = {
+                "median": float(y.median()) if not y.empty else 0,
+                "lower": float(y.quantile(self.quantile_lower)) if not y.empty else 0,
+                "upper": float(y.quantile(self.quantile_upper)) if not y.empty else 0,
+            }
+            self._is_fitted = True
+            return self
+
+        self._feature_names = list(X.columns)
+
+        try:
+            self._fit_sklearn(X, y)
+        except ImportError:
+            # sklearn not available — use percentile fallback
+            self._fallback_percentiles = {
+                "median": float(y.median()),
+                "lower": float(y.quantile(self.quantile_lower)),
+                "upper": float(y.quantile(self.quantile_upper)),
+            }
+
+        self._is_fitted = True
+        return self
+
+    def _fit_sklearn(self, X: pd.DataFrame, y: pd.Series) -> None:
+        """Fit using sklearn estimators."""
+        from sklearn.ensemble import (
+            GradientBoostingRegressor,
+            RandomForestRegressor,
+        )
+
+        X_arr = X.values.astype(np.float64)
+        y_arr = y.values.astype(np.float64)
+
+        # Remove NaN rows
+        mask = ~(np.isnan(X_arr).any(axis=1) | np.isnan(y_arr))
+        X_arr = X_arr[mask]
+        y_arr = y_arr[mask]
+
+        if len(y_arr) < 2:
+            self._fallback_percentiles = {
+                "median": float(np.median(y_arr)) if len(y_arr) > 0 else 0,
+                "lower": 0,
+                "upper": float(np.max(y_arr)) if len(y_arr) > 0 else 0,
+            }
+            return
+
+        if self.model_type == "random_forest":
+            self._model = RandomForestRegressor(
+                n_estimators=50,
+                max_depth=8,
+                random_state=self.random_state,
+                n_jobs=-1,
+            )
+            self._model.fit(X_arr, y_arr)
+            # For RF, use quantile estimation from tree predictions
+            self._model_lower = None
+            self._model_upper = None
+        elif self.model_type == "quantile_regression":
+            # Use gradient boosting with quantile loss
+            self._model = GradientBoostingRegressor(
+                n_estimators=100,
+                max_depth=5,
+                loss="squared_error",
+                random_state=self.random_state,
+            )
+            self._model.fit(X_arr, y_arr)
+            self._model_lower = GradientBoostingRegressor(
+                n_estimators=100,
+                max_depth=5,
+                loss="quantile",
+                alpha=self.quantile_lower,
+                random_state=self.random_state,
+            )
+            self._model_lower.fit(X_arr, y_arr)
+            self._model_upper = GradientBoostingRegressor(
+                n_estimators=100,
+                max_depth=5,
+                loss="quantile",
+                alpha=self.quantile_upper,
+                random_state=self.random_state,
+            )
+            self._model_upper.fit(X_arr, y_arr)
+        else:
+            # Default: gradient_boosting
+            self._model = GradientBoostingRegressor(
+                n_estimators=100,
+                max_depth=5,
+                loss="squared_error",
+                random_state=self.random_state,
+            )
+            self._model.fit(X_arr, y_arr)
+            # Use residuals for interval estimation
+            self._model_lower = None
+            self._model_upper = None
+
+    def predict(self, X: pd.DataFrame) -> list[PredictionResult]:
+        """Predict target values with confidence intervals.
+
+        Parameters
+        ----------
+        X
+            Feature matrix (same columns as training data).
+
+        Returns
+        -------
+        list[PredictionResult]
+            One prediction per row in X.
+        """
+        if not self._is_fitted:
+            raise RuntimeError("Model not fitted. Call .fit() first.")
+
+        if self._fallback_percentiles is not None:
+            # Percentile fallback
+            return [
+                PredictionResult(
+                    point=self._fallback_percentiles["median"],
+                    lower=self._fallback_percentiles["lower"],
+                    upper=self._fallback_percentiles["upper"],
+                    confidence=self.quantile_upper - self.quantile_lower,
+                )
+                for _ in range(len(X))
+            ]
+
+        return self._predict_sklearn(X)
+
+    def _predict_sklearn(self, X: pd.DataFrame) -> list[PredictionResult]:
+        """Predict using fitted sklearn models."""
+        # Align columns with training
+        aligned = X.reindex(columns=self._feature_names, fill_value=0)
+        X_arr = aligned.values.astype(np.float64)
+        np.nan_to_num(X_arr, copy=False)
+
+        points = self._model.predict(X_arr)
+
+        if self._model_lower is not None and self._model_upper is not None:
+            lowers = self._model_lower.predict(X_arr)
+            uppers = self._model_upper.predict(X_arr)
+        elif self.model_type == "random_forest":
+            # Use individual tree predictions for intervals
+            tree_preds = np.array([t.predict(X_arr) for t in self._model.estimators_])
+            lowers = np.percentile(tree_preds, self.quantile_lower * 100, axis=0)
+            uppers = np.percentile(tree_preds, self.quantile_upper * 100, axis=0)
+        else:
+            # Heuristic interval: ±30% of point prediction
+            lowers = points * 0.7
+            uppers = points * 1.3
+
+        results = []
+        for i in range(len(points)):
+            results.append(
+                PredictionResult(
+                    point=float(max(0, points[i])),
+                    lower=float(max(0, lowers[i])),
+                    upper=float(max(0, uppers[i])),
+                    confidence=self.quantile_upper - self.quantile_lower,
+                )
+            )
+        return results
+
+    def feature_importances(self) -> dict[str, float]:
+        """Return feature importance scores if available."""
+        if self._model is None or not hasattr(self._model, "feature_importances_"):
+            return {}
+        importances = self._model.feature_importances_
+        return dict(zip(self._feature_names, [float(v) for v in importances], strict=False))
+
+    def save(self, path: str | Path) -> None:
+        """Persist model to disk."""
+        path = Path(path)
+        path.mkdir(parents=True, exist_ok=True)
+
+        meta = {
+            "model_type": self.model_type,
+            "quantile_lower": self.quantile_lower,
+            "quantile_upper": self.quantile_upper,
+            "feature_names": self._feature_names,
+            "is_fitted": self._is_fitted,
+            "fallback_percentiles": self._fallback_percentiles,
+        }
+        (path / "metadata.json").write_text(json.dumps(meta, indent=2))
+
+        if self._model is not None:
+            try:
+                import joblib
+
+                joblib.dump(self._model, path / "model.joblib")
+                if self._model_lower is not None:
+                    joblib.dump(self._model_lower, path / "model_lower.joblib")
+                if self._model_upper is not None:
+                    joblib.dump(self._model_upper, path / "model_upper.joblib")
+            except ImportError:
+                pass  # Cannot persist without joblib
+
+    @classmethod
+    def load(cls, path: str | Path) -> ResourceModel:
+        """Load a persisted model from disk."""
+        path = Path(path)
+        meta_text = (path / "metadata.json").read_text()
+        meta = json.loads(meta_text)
+
+        instance = cls(
+            model_type=meta["model_type"],
+            quantile_lower=meta.get("quantile_lower", 0.05),
+            quantile_upper=meta.get("quantile_upper", 0.95),
+        )
+        instance._feature_names = meta.get("feature_names", [])
+        instance._is_fitted = meta.get("is_fitted", False)
+        instance._fallback_percentiles = meta.get("fallback_percentiles")
+
+        model_path = path / "model.joblib"
+        if model_path.exists():
+            try:
+                import joblib
+
+                instance._model = joblib.load(model_path)
+                lower_path = path / "model_lower.joblib"
+                upper_path = path / "model_upper.joblib"
+                if lower_path.exists():
+                    instance._model_lower = joblib.load(lower_path)
+                if upper_path.exists():
+                    instance._model_upper = joblib.load(upper_path)
+            except ImportError:
+                pass
+
+        return instance
+
+
+__all__ = ["ModelQuality", "PredictionResult", "ResourceModel"]

--- a/scalable/ml/tuning.py
+++ b/scalable/ml/tuning.py
@@ -1,0 +1,201 @@
+"""Distributed hyperparameter tuning via Dask-ML (Phase 5).
+
+Provides a thin wrapper around Dask-ML search strategies for distributed
+model selection within a Scalable session. Falls back to sequential sklearn
+search when Dask-ML is unavailable.
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from typing import Any
+
+import pandas as pd
+
+
+@dataclass(frozen=True)
+class TuningResult:
+    """Result of a hyperparameter search."""
+
+    best_params: dict[str, Any]
+    best_score: float
+    all_results: pd.DataFrame
+    best_estimator: Any
+    n_iterations: int
+    wall_time_s: float
+    strategy: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "best_params": self.best_params,
+            "best_score": self.best_score,
+            "n_iterations": self.n_iterations,
+            "wall_time_s": self.wall_time_s,
+            "strategy": self.strategy,
+        }
+
+
+class HyperparameterSearch:
+    """Distributed hyperparameter tuning via Dask-ML.
+
+    Supports hyperband, successive halving, and random search strategies.
+    Falls back to sklearn's ``RandomizedSearchCV`` when Dask-ML is not
+    available.
+
+    Parameters
+    ----------
+    estimator
+        An sklearn-compatible estimator to tune.
+    param_space
+        Parameter search space. For Dask-ML hyperband, use scipy
+        distributions. For random search, use lists or distributions.
+    strategy
+        Search strategy: ``"hyperband"``, ``"successive_halving"``, or
+        ``"random"``.
+    n_iter
+        Maximum number of parameter combinations to evaluate.
+    scoring
+        Scoring metric name (sklearn convention, e.g., ``"neg_mean_absolute_error"``).
+    random_state
+        Random state for reproducibility.
+    """
+
+    def __init__(
+        self,
+        estimator: Any,
+        param_space: dict[str, Any],
+        *,
+        strategy: str = "hyperband",
+        n_iter: int = 50,
+        scoring: str | None = None,
+        random_state: int = 42,
+    ) -> None:
+        self.estimator = estimator
+        self.param_space = param_space
+        self.strategy = strategy
+        self.n_iter = n_iter
+        self.scoring = scoring or "neg_mean_absolute_error"
+        self.random_state = random_state
+
+    def fit(
+        self,
+        X: Any,
+        y: Any,
+        *,
+        client: Any | None = None,
+    ) -> TuningResult:
+        """Run the hyperparameter search.
+
+        Parameters
+        ----------
+        X
+            Training features (numpy array, pandas DataFrame, or dask array).
+        y
+            Training target.
+        client
+            Optional Dask client for distributed execution. If ``None``,
+            falls back to local sequential search.
+
+        Returns
+        -------
+        TuningResult
+            Best parameters, score, and full results.
+        """
+        start_time = time.time()
+
+        try:
+            result = self._fit_dask_ml(X, y, client=client)
+        except ImportError:
+            result = self._fit_sklearn_fallback(X, y)
+
+        wall_time = time.time() - start_time
+        return TuningResult(
+            best_params=result["best_params"],
+            best_score=result["best_score"],
+            all_results=result.get("all_results", pd.DataFrame()),
+            best_estimator=result["best_estimator"],
+            n_iterations=result.get("n_iterations", self.n_iter),
+            wall_time_s=wall_time,
+            strategy=self.strategy,
+        )
+
+    def _fit_dask_ml(self, X: Any, y: Any, *, client: Any) -> dict[str, Any]:
+        """Fit using Dask-ML search strategies."""
+        from dask_ml.model_selection import HyperbandSearchCV, RandomizedSearchCV
+
+        if self.strategy == "hyperband":
+            search = HyperbandSearchCV(
+                self.estimator,
+                self.param_space,
+                max_iter=self.n_iter,
+                random_state=self.random_state,
+            )
+        elif self.strategy == "successive_halving":
+            # Dask-ML's HyperbandSearchCV with aggressive_elimination is
+            # equivalent to successive halving
+            search = HyperbandSearchCV(
+                self.estimator,
+                self.param_space,
+                max_iter=self.n_iter,
+                aggressiveness=4,
+                random_state=self.random_state,
+            )
+        else:
+            # random
+            search = RandomizedSearchCV(
+                self.estimator,
+                self.param_space,
+                n_iter=self.n_iter,
+                scoring=self.scoring,
+                random_state=self.random_state,
+            )
+
+        search.fit(X, y)
+
+        cv_results = pd.DataFrame(search.cv_results_) if hasattr(search, "cv_results_") else pd.DataFrame()
+
+        return {
+            "best_params": search.best_params_,
+            "best_score": float(search.best_score_),
+            "best_estimator": search.best_estimator_,
+            "all_results": cv_results,
+            "n_iterations": len(cv_results) if not cv_results.empty else self.n_iter,
+        }
+
+    def _fit_sklearn_fallback(self, X: Any, y: Any) -> dict[str, Any]:
+        """Fallback to sklearn's RandomizedSearchCV."""
+        try:
+            from sklearn.model_selection import RandomizedSearchCV
+
+            search = RandomizedSearchCV(
+                self.estimator,
+                self.param_space,
+                n_iter=min(self.n_iter, 20),  # Cap for sequential search
+                scoring=self.scoring,
+                cv=3,
+                random_state=self.random_state,
+                n_jobs=-1,
+            )
+            search.fit(X, y)
+
+            cv_results = pd.DataFrame(search.cv_results_)
+            return {
+                "best_params": search.best_params_,
+                "best_score": float(search.best_score_),
+                "best_estimator": search.best_estimator_,
+                "all_results": cv_results,
+                "n_iterations": len(cv_results),
+            }
+        except ImportError:
+            # No sklearn either — return trivial result
+            return {
+                "best_params": {},
+                "best_score": 0.0,
+                "best_estimator": self.estimator,
+                "all_results": pd.DataFrame(),
+                "n_iterations": 0,
+            }
+
+
+__all__ = ["HyperparameterSearch", "TuningResult"]

--- a/scalable/ml/validation.py
+++ b/scalable/ml/validation.py
@@ -1,0 +1,134 @@
+"""Cross-validation and model quality assessment for resource models."""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+from scalable.ml.features import FeatureExtractor
+from scalable.ml.models import ModelQuality, ResourceModel
+
+
+def cross_validate_advisor(
+    records: pd.DataFrame,
+    *,
+    model_type: str = "gradient_boosting",
+    target_column: str = "duration_num",
+    n_splits: int = 5,
+    random_state: int = 42,
+) -> ModelQuality:
+    """Cross-validate a resource model against historical telemetry.
+
+    Parameters
+    ----------
+    records
+        Raw telemetry records (same format as ResourceAdvisor internal frame).
+    model_type
+        Model type to evaluate (``gradient_boosting``, ``random_forest``,
+        ``quantile_regression``).
+    target_column
+        Target column to predict (``duration_num`` or ``requested_memory_num``).
+    n_splits
+        Number of cross-validation folds.
+    random_state
+        Random state for reproducibility.
+
+    Returns
+    -------
+    ModelQuality
+        Aggregated quality metrics across all folds.
+    """
+    extractor = FeatureExtractor()
+    features = extractor.extract_from_history(records)
+
+    if features.empty or target_column not in features.columns:
+        return ModelQuality(
+            mae=float("inf"),
+            rmse=float("inf"),
+            r2=0.0,
+            coverage=0.0,
+            n_samples=0,
+            model_type=model_type,
+            target_name=target_column,
+        )
+
+    # Filter rows with valid target
+    valid_mask = features[target_column].notna() & (features[target_column] > 0)
+    features = features[valid_mask].reset_index(drop=True)
+
+    if len(features) < n_splits * 2:
+        return ModelQuality(
+            mae=float("inf"),
+            rmse=float("inf"),
+            r2=0.0,
+            coverage=0.0,
+            n_samples=len(features),
+            model_type=model_type,
+            target_name=target_column,
+        )
+
+    y = features[target_column]
+    X = features.drop(columns=[target_column, "requested_memory_num"], errors="ignore")
+
+    # Simple k-fold (no sklearn dependency required for splitting)
+    indices = np.arange(len(features))
+    rng = np.random.default_rng(random_state)
+    rng.shuffle(indices)
+    folds = np.array_split(indices, n_splits)
+
+    all_errors: list[float] = []
+    all_sq_errors: list[float] = []
+    all_in_interval: list[bool] = []
+    all_y_true: list[float] = []
+    all_y_pred: list[float] = []
+
+    for i in range(n_splits):
+        test_idx = folds[i]
+        train_idx = np.concatenate([folds[j] for j in range(n_splits) if j != i])
+
+        X_train = X.iloc[train_idx]
+        y_train = y.iloc[train_idx]
+        X_test = X.iloc[test_idx]
+        y_test = y.iloc[test_idx]
+
+        model = ResourceModel(model_type=model_type, random_state=random_state)
+        model.fit(X_train, y_train)
+        predictions = model.predict(X_test)
+
+        for pred, true_val in zip(predictions, y_test, strict=False):
+            error = abs(pred.point - true_val)
+            all_errors.append(error)
+            all_sq_errors.append(error**2)
+            all_y_true.append(true_val)
+            all_y_pred.append(pred.point)
+
+            # Check if true value is within predicted interval
+            if pred.lower is not None and pred.upper is not None:
+                in_interval = pred.lower <= true_val <= pred.upper
+            else:
+                in_interval = True  # No interval means no coverage check
+            all_in_interval.append(in_interval)
+
+    mae = float(np.mean(all_errors))
+    rmse = float(np.sqrt(np.mean(all_sq_errors)))
+    coverage = float(np.mean(all_in_interval))
+
+    # R² calculation
+    y_true_arr = np.array(all_y_true)
+    y_pred_arr = np.array(all_y_pred)
+    ss_res = np.sum((y_true_arr - y_pred_arr) ** 2)
+    ss_tot = np.sum((y_true_arr - np.mean(y_true_arr)) ** 2)
+    r2 = float(1 - ss_res / ss_tot) if ss_tot > 0 else 0.0
+
+    return ModelQuality(
+        mae=mae,
+        rmse=rmse,
+        r2=r2,
+        coverage=coverage,
+        n_samples=len(features),
+        model_type=model_type,
+        target_name=target_column,
+    )
+
+
+__all__ = ["cross_validate_advisor"]

--- a/scalable/session/session.py
+++ b/scalable/session/session.py
@@ -272,8 +272,6 @@ def _apply_objective_policy(
     Phase 4 implementation uses heuristic rules. Phase 5 will add
     ML-backed optimizations using the same API surface.
     """
-    from dataclasses import replace as dc_replace
-
     from scalable.providers.base import ResourceRequest, ScalePlan
 
     effective_objective = (objective or "balance").lower().strip()

--- a/scalable/telemetry/events.py
+++ b/scalable/telemetry/events.py
@@ -203,10 +203,38 @@ class RemoteCacheEvent:
         return asdict(self)
 
 
+@dataclass(frozen=True)
+class EmulationEvent:
+    """Emulation dispatch event record (Phase 5).
+
+    Recorded when a function is routed through the emulator dispatch
+    pipeline, whether it ends up being emulated or falling back to the
+    full model.
+    """
+
+    run_id: str
+    task_name: str
+    component: str | None
+    emulator_name: str | None
+    source: str  # "emulator" | "full_model" | "cached"
+    confidence: float | None
+    fallback_reason: str | None
+    domain_valid: bool
+    timestamp: str = field(default_factory=utcnow_iso)
+    emulator_version: str | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+    event_type: str = "emulation"
+    schema_version: int = SCHEMA_VERSION
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
 __all__ = [
     "ArtifactEvent",
     "CacheEvent",
     "CostEvent",
+    "EmulationEvent",
     "FailureEvent",
     "RemoteCacheEvent",
     "ResourceEvent",

--- a/tests/unit/test_ai_explain.py
+++ b/tests/unit/test_ai_explain.py
@@ -8,7 +8,6 @@ import pytest
 
 from scalable.ai.plan_explain import ExplanationResult, explain_plan
 
-
 SAMPLE_PLAN = {
     "version": 1,
     "target": "local",

--- a/tests/unit/test_ai_onboarding.py
+++ b/tests/unit/test_ai_onboarding.py
@@ -54,7 +54,7 @@ class TestOnboardComponent:
 
         # The YAML portion should be parseable (after stripping comments)
         lines = result.component_yaml.split("\n")
-        yaml_lines = [l for l in lines if not l.startswith("#")]
+        yaml_lines = [line for line in lines if not line.startswith("#")]
         yaml_content = "\n".join(yaml_lines)
         parsed = yaml.safe_load(yaml_content)
         assert parsed is not None

--- a/tests/unit/test_emulation.py
+++ b/tests/unit/test_emulation.py
@@ -1,0 +1,440 @@
+"""Tests for scalable.emulation — decorator, registry, dispatch, uncertainty, active learning."""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from scalable.emulation.active_learning import ActiveLearner
+from scalable.emulation.decorator import (
+    EmulationSpec,
+    emulatable,
+    get_emulation_spec,
+    get_original_function,
+    list_emulatable_functions,
+)
+from scalable.emulation.dispatch import EmulatorDispatch, EmulatorDispatchResult
+from scalable.emulation.registry import EmulatorInfo, EmulatorRegistry
+from scalable.emulation.surrogate import (
+    EmulatorMetadata,
+    EmulatorPrediction,
+    GradientBoostingEmulator,
+    RandomForestEmulator,
+)
+from scalable.emulation.uncertainty import (
+    CalibrationResult,
+    calibrate_emulator,
+    compute_confidence_from_uncertainty,
+    is_in_domain,
+)
+
+# ─── Decorator tests ───
+
+
+class TestEmulatable:
+    def test_basic_decoration(self):
+        @emulatable(
+            tag="gcam",
+            inputs=["carbon_price", "population"],
+            outputs=["emissions"],
+            confidence_threshold=0.9,
+        )
+        def run_gcam(params):
+            return {"emissions": 100}
+
+        spec = get_emulation_spec(run_gcam)
+        assert spec is not None
+        assert spec.tag == "gcam"
+        assert spec.inputs == ["carbon_price", "population"]
+        assert spec.outputs == ["emissions"]
+        assert spec.confidence_threshold == 0.9
+
+    def test_direct_call_runs_original(self):
+        @emulatable(tag="test", inputs=["x"], outputs=["y"])
+        def compute(x):
+            return x * 2
+
+        assert compute(5) == 10
+
+    def test_get_original_function(self):
+        @emulatable(tag="test", inputs=["x"], outputs=["y"])
+        def compute(x):
+            return x * 2
+
+        original = get_original_function(compute)
+        assert original(3) == 6
+
+    def test_invalid_uncertainty(self):
+        with pytest.raises(ValueError, match="uncertainty"):
+
+            @emulatable(tag="t", inputs=[], outputs=[], uncertainty="invalid")
+            def f():
+                pass
+
+    def test_invalid_fallback(self):
+        with pytest.raises(ValueError, match="fallback"):
+
+            @emulatable(tag="t", inputs=[], outputs=[], fallback="invalid")
+            def f():
+                pass
+
+    def test_invalid_confidence(self):
+        with pytest.raises(ValueError, match="confidence_threshold"):
+
+            @emulatable(tag="t", inputs=[], outputs=[], confidence_threshold=2.0)
+            def f():
+                pass
+
+    def test_list_emulatable_functions(self):
+        registry = list_emulatable_functions()
+        assert isinstance(registry, dict)
+
+
+# ─── Surrogate model tests ───
+
+
+class TestSurrogateModels:
+    def _make_metadata(self):
+        return EmulatorMetadata(
+            name="test_emulator",
+            version="1",
+            training_runs=["run-1"],
+            training_samples=100,
+            validation_score=0.95,
+            domain_bounds={"x": (0.0, 10.0)},
+            created_at="2026-01-01T00:00:00Z",
+            model_type="gradient_boosting",
+            input_names=["x", "y"],
+            output_names=["z"],
+        )
+
+    def test_gradient_boosting_emulator_no_model(self):
+        meta = self._make_metadata()
+        emu = GradientBoostingEmulator(metadata=meta)
+        pred = emu.predict({"x": 5, "y": 3})
+        assert pred.confidence == 0.0
+        assert pred.is_emulated
+
+    def test_random_forest_emulator_no_model(self):
+        meta = self._make_metadata()
+        emu = RandomForestEmulator(metadata=meta)
+        pred = emu.predict({"x": 5, "y": 3})
+        assert pred.confidence == 0.0
+
+    def test_emulator_prediction_dataclass(self):
+        pred = EmulatorPrediction(
+            outputs={"z": 42.0},
+            confidence=0.95,
+            uncertainty_bounds={"z": (38.0, 46.0)},
+        )
+        assert pred.outputs["z"] == 42.0
+        assert pred.is_emulated
+        d = pred.to_dict()
+        assert d["confidence"] == 0.95
+
+    def test_emulator_metadata_to_dict(self):
+        meta = self._make_metadata()
+        d = meta.to_dict()
+        assert d["name"] == "test_emulator"
+        assert d["model_type"] == "gradient_boosting"
+
+
+# ─── Registry tests ───
+
+
+class _MockEmulator:
+    """Mock emulator for testing registry without sklearn."""
+
+    def __init__(self, name="mock", version="1"):
+        self._metadata = EmulatorMetadata(
+            name=name,
+            version=version,
+            training_runs=["run-1"],
+            training_samples=50,
+            validation_score=0.9,
+            domain_bounds={"x": (0.0, 100.0)},
+            created_at="2026-01-01T00:00:00Z",
+            model_type="mock",
+            input_names=["x"],
+            output_names=["y"],
+        )
+
+    @property
+    def metadata(self) -> EmulatorMetadata:
+        return self._metadata
+
+    def predict(self, inputs):
+        return EmulatorPrediction(
+            outputs={"y": float(inputs.get("x", 0)) * 2},
+            confidence=0.95,
+            uncertainty_bounds={"y": (0.0, 200.0)},
+        )
+
+    def uncertainty(self, inputs):
+        return 0.05
+
+
+class TestEmulatorRegistry:
+    def test_register_and_get(self, tmp_path):
+        registry = EmulatorRegistry(tmp_path / "emulators")
+        emu = _MockEmulator("test", "1")
+        version = registry.register("test", emu)
+        assert version == "1"
+
+        retrieved = registry.get("test")
+        assert retrieved is emu
+
+    def test_auto_version_increment(self, tmp_path):
+        registry = EmulatorRegistry(tmp_path / "emulators")
+        emu1 = _MockEmulator("test", "1")
+        emu2 = _MockEmulator("test", "2")
+        registry.register("test", emu1, version="1")
+        version = registry.register("test", emu2)
+        assert version == "2"
+
+    def test_get_latest(self, tmp_path):
+        registry = EmulatorRegistry(tmp_path / "emulators")
+        emu1 = _MockEmulator("test", "1")
+        emu2 = _MockEmulator("test", "2")
+        registry.register("test", emu1, version="1")
+        registry.register("test", emu2, version="2")
+        retrieved = registry.get("test")
+        assert retrieved is emu2
+
+    def test_get_specific_version(self, tmp_path):
+        registry = EmulatorRegistry(tmp_path / "emulators")
+        emu1 = _MockEmulator("test", "1")
+        emu2 = _MockEmulator("test", "2")
+        registry.register("test", emu1, version="1")
+        registry.register("test", emu2, version="2")
+        retrieved = registry.get("test", version="1")
+        assert retrieved is emu1
+
+    def test_get_not_found(self, tmp_path):
+        registry = EmulatorRegistry(tmp_path / "emulators")
+        with pytest.raises(KeyError, match="not found"):
+            registry.get("nonexistent")
+
+    def test_list_emulators(self, tmp_path):
+        registry = EmulatorRegistry(tmp_path / "emulators")
+        registry.register("emu1", _MockEmulator("emu1", "1"))
+        registry.register("emu2", _MockEmulator("emu2", "1"))
+        listing = registry.list()
+        assert len(listing) == 2
+        names = {e.name for e in listing}
+        assert "emu1" in names
+        assert "emu2" in names
+
+    def test_validate_domain_in_bounds(self, tmp_path):
+        registry = EmulatorRegistry(tmp_path / "emulators")
+        registry.register("test", _MockEmulator())
+        assert registry.validate_domain("test", {"x": 50.0})
+
+    def test_validate_domain_out_of_bounds(self, tmp_path):
+        registry = EmulatorRegistry(tmp_path / "emulators")
+        registry.register("test", _MockEmulator())
+        assert not registry.validate_domain("test", {"x": 200.0})
+
+    def test_remove(self, tmp_path):
+        registry = EmulatorRegistry(tmp_path / "emulators")
+        registry.register("test", _MockEmulator())
+        registry.remove("test")
+        with pytest.raises(KeyError):
+            registry.get("test")
+
+
+# ─── Dispatch tests ───
+
+
+class TestEmulatorDispatch:
+    def test_dispatch_with_emulator(self, tmp_path):
+        registry = EmulatorRegistry(tmp_path / "emulators")
+        registry.register("run_model", _MockEmulator("run_model", "1"))
+
+        @emulatable(
+            tag="test",
+            inputs=["x"],
+            outputs=["y"],
+            confidence_threshold=0.9,
+        )
+        def run_model(x=0):
+            return {"y": x * 3}
+
+        dispatch = EmulatorDispatch(registry)
+        result = dispatch.execute(run_model, emulator_name="run_model", x=50)
+        assert result.source == "emulator"
+        assert result.confidence == 0.95
+
+    def test_dispatch_fallback_low_confidence(self, tmp_path):
+        """When emulator confidence is below threshold, use full model."""
+
+        class LowConfEmulator(_MockEmulator):
+            def predict(self, inputs):
+                return EmulatorPrediction(
+                    outputs={"y": 0}, confidence=0.5, uncertainty_bounds={"y": (0, 100)}
+                )
+
+        registry = EmulatorRegistry(tmp_path / "emulators")
+        registry.register("run_model", LowConfEmulator())
+
+        @emulatable(
+            tag="test",
+            inputs=["x"],
+            outputs=["y"],
+            confidence_threshold=0.9,
+        )
+        def run_model(x=0):
+            return {"y": x * 3}
+
+        dispatch = EmulatorDispatch(registry)
+        result = dispatch.execute(run_model, emulator_name="run_model", x=5)
+        assert result.source == "full_model"
+        assert "low_confidence" in result.fallback_reason
+
+    def test_dispatch_no_spec(self, tmp_path):
+        registry = EmulatorRegistry(tmp_path / "emulators")
+        dispatch = EmulatorDispatch(registry)
+
+        def plain_func(x):
+            return x + 1
+
+        result = dispatch.execute(plain_func, 5)
+        assert result.source == "full_model"
+        assert result.result == 6
+
+    def test_dispatch_force_full_model(self, tmp_path):
+        registry = EmulatorRegistry(tmp_path / "emulators")
+        registry.register("run_model", _MockEmulator("run_model", "1"))
+
+        @emulatable(tag="test", inputs=["x"], outputs=["y"])
+        def run_model(x=0):
+            return {"y": x * 3}
+
+        dispatch = EmulatorDispatch(registry)
+        result = dispatch.execute(run_model, emulator_name="run_model", force_full_model=True, x=5)
+        assert result.source == "full_model"
+
+    def test_dispatch_outside_domain(self, tmp_path):
+        registry = EmulatorRegistry(tmp_path / "emulators")
+        registry.register("run_model", _MockEmulator("run_model", "1"))
+
+        @emulatable(
+            tag="test",
+            inputs=["x"],
+            outputs=["y"],
+            domain={"x": (0, 100)},
+        )
+        def run_model(x=0):
+            return {"y": x * 3}
+
+        dispatch = EmulatorDispatch(registry)
+        result = dispatch.execute(run_model, emulator_name="run_model", x=200)
+        assert result.source == "full_model"
+        assert "outside_domain" in result.fallback_reason
+
+    def test_dispatch_log(self, tmp_path):
+        registry = EmulatorRegistry(tmp_path / "emulators")
+        dispatch = EmulatorDispatch(registry, record_provenance=True)
+
+        def f():
+            return 1
+
+        dispatch.execute(f)
+        assert len(dispatch.dispatch_log) == 1
+
+
+# ─── Uncertainty tests ───
+
+
+class TestUncertainty:
+    def test_calibrate_emulator_perfect(self):
+        predictions = [
+            {"outputs": {"y": 10}, "uncertainty_bounds": {"y": [5, 15]}},
+            {"outputs": {"y": 20}, "uncertainty_bounds": {"y": [15, 25]}},
+            {"outputs": {"y": 30}, "uncertainty_bounds": {"y": [25, 35]}},
+        ]
+        actuals = [{"y": 10}, {"y": 20}, {"y": 30}]
+        result = calibrate_emulator(predictions, actuals, output_name="y")
+        assert result.coverage_95 == 1.0
+        assert result.is_calibrated
+
+    def test_calibrate_emulator_poor(self):
+        predictions = [
+            {"outputs": {"y": 10}, "uncertainty_bounds": {"y": [9, 11]}},
+            {"outputs": {"y": 20}, "uncertainty_bounds": {"y": [19, 21]}},
+        ]
+        actuals = [{"y": 50}, {"y": 100}]  # Way outside bounds
+        result = calibrate_emulator(predictions, actuals, output_name="y")
+        assert result.coverage_95 == 0.0
+        assert not result.is_calibrated
+
+    def test_calibrate_empty(self):
+        result = calibrate_emulator([], [], output_name="y")
+        assert result.n_samples == 0
+        assert not result.is_calibrated
+
+    def test_compute_confidence(self):
+        assert compute_confidence_from_uncertainty(0.0) == 1.0
+        assert compute_confidence_from_uncertainty(1.0) == 0.0
+        assert 0.0 < compute_confidence_from_uncertainty(0.5) < 1.0
+
+    def test_is_in_domain(self):
+        domain = {"x": (0.0, 10.0), "y": (-5.0, 5.0)}
+        assert is_in_domain({"x": 5.0, "y": 0.0}, domain)
+        assert not is_in_domain({"x": 15.0, "y": 0.0}, domain)
+        assert is_in_domain({"z": 999.0}, domain)  # Unknown keys are fine
+
+
+# ─── Active learning tests ───
+
+
+class TestActiveLearner:
+    def test_suggest_random(self):
+        learner = ActiveLearner(
+            emulator=_MockEmulator(),
+            acquisition="random",
+            random_state=42,
+        )
+        candidates = pd.DataFrame({"x": [1, 2, 3, 4, 5]})
+        selected = learner.suggest(candidates, n_suggestions=2)
+        assert len(selected) == 2
+
+    def test_suggest_uncertainty(self):
+        learner = ActiveLearner(
+            emulator=_MockEmulator(),
+            acquisition="uncertainty",
+        )
+        candidates = pd.DataFrame({"x": [1, 2, 3, 4, 5]})
+        selected = learner.suggest(candidates, n_suggestions=2)
+        assert len(selected) == 2
+
+    def test_suggest_expected_improvement(self):
+        learner = ActiveLearner(
+            emulator=_MockEmulator(),
+            acquisition="expected_improvement",
+        )
+        candidates = pd.DataFrame({"x": [1, 2, 3, 4, 5]})
+        selected = learner.suggest(candidates, n_suggestions=2)
+        assert len(selected) == 2
+
+    def test_update_observations(self):
+        learner = ActiveLearner(emulator=_MockEmulator(), acquisition="random")
+        assert learner.n_observations == 0
+        learner.update(pd.DataFrame({"x": [1, 2, 3]}))
+        assert learner.n_observations == 3
+
+    def test_empty_candidates(self):
+        learner = ActiveLearner(emulator=_MockEmulator(), acquisition="random")
+        selected = learner.suggest(pd.DataFrame(), n_suggestions=5)
+        assert len(selected) == 0
+
+    def test_invalid_acquisition(self):
+        with pytest.raises(ValueError, match="acquisition"):
+            ActiveLearner(emulator=_MockEmulator(), acquisition="invalid")
+
+    def test_reset(self):
+        learner = ActiveLearner(emulator=_MockEmulator(), acquisition="random")
+        learner.update(pd.DataFrame({"x": [1, 2]}))
+        learner.reset()
+        assert learner.n_observations == 0

--- a/tests/unit/test_ml_adaptive_scaler.py
+++ b/tests/unit/test_ml_adaptive_scaler.py
@@ -1,0 +1,147 @@
+"""Tests for scalable.ml.adaptive_scaler — adaptive scaling policy."""
+
+from __future__ import annotations
+
+import pytest
+
+from scalable.ml.adaptive_scaler import AdaptiveScaler, ScaleDecision
+
+
+class TestScaleDecision:
+    def test_no_changes(self):
+        d = ScaleDecision(
+            workers_to_add={},
+            workers_to_remove={},
+            reasoning="no changes",
+            confidence=0.9,
+        )
+        assert not d.has_changes
+
+    def test_has_changes_add(self):
+        d = ScaleDecision(
+            workers_to_add={"gcam": 2},
+            workers_to_remove={},
+            reasoning="scale up",
+            confidence=0.8,
+        )
+        assert d.has_changes
+
+    def test_to_dict(self):
+        d = ScaleDecision(
+            workers_to_add={"gcam": 1},
+            workers_to_remove={"stitches": 1},
+            reasoning="rebalance",
+            confidence=0.85,
+            predicted_completion_time=300.0,
+        )
+        result = d.to_dict()
+        assert result["workers_to_add"] == {"gcam": 1}
+        assert result["confidence"] == 0.85
+
+
+class TestAdaptiveScaler:
+    def test_cooldown_blocks_rapid_decisions(self):
+        scaler = AdaptiveScaler(cooldown_seconds=60.0)
+        # First evaluation
+        decision1 = scaler.evaluate(
+            pending_tasks=[{"tag": "gcam"}],
+            active_workers={"gcam": 0},
+        )
+        assert decision1.has_changes
+
+        # Second evaluation within cooldown
+        decision2 = scaler.evaluate(
+            pending_tasks=[{"tag": "gcam"}],
+            active_workers={"gcam": 1},
+        )
+        assert not decision2.has_changes
+        assert "Cooldown" in decision2.reasoning
+
+    def test_scale_up_on_high_queue(self):
+        scaler = AdaptiveScaler(
+            scale_up_threshold=0.8,
+            cooldown_seconds=0,
+        )
+        decision = scaler.evaluate(
+            pending_tasks=[{"tag": "gcam"}] * 10,
+            active_workers={"gcam": 2},
+        )
+        assert decision.workers_to_add.get("gcam", 0) > 0
+
+    def test_scale_down_on_low_queue(self):
+        scaler = AdaptiveScaler(
+            scale_down_threshold=0.2,
+            cooldown_seconds=0,
+            min_workers={"gcam": 1},
+        )
+        decision = scaler.evaluate(
+            pending_tasks=[],  # No pending tasks
+            active_workers={"gcam": 5},
+        )
+        assert decision.workers_to_remove.get("gcam", 0) > 0
+
+    def test_respects_max_workers(self):
+        scaler = AdaptiveScaler(
+            max_workers={"gcam": 3},
+            cooldown_seconds=0,
+        )
+        decision = scaler.evaluate(
+            pending_tasks=[{"tag": "gcam"}] * 100,
+            active_workers={"gcam": 0},
+        )
+        assert decision.workers_to_add.get("gcam", 0) <= 3
+
+    def test_respects_min_workers(self):
+        scaler = AdaptiveScaler(
+            min_workers={"gcam": 2},
+            cooldown_seconds=0,
+        )
+        decision = scaler.evaluate(
+            pending_tasks=[],
+            active_workers={"gcam": 5},
+        )
+        # Should not remove below minimum
+        removed = decision.workers_to_remove.get("gcam", 0)
+        remaining = 5 - removed
+        assert remaining >= 2
+
+    def test_no_workers_triggers_scaleup(self):
+        scaler = AdaptiveScaler(cooldown_seconds=0)
+        decision = scaler.evaluate(
+            pending_tasks=[{"tag": "gcam"}, {"tag": "gcam"}],
+            active_workers={"gcam": 0},
+        )
+        assert decision.workers_to_add.get("gcam", 0) > 0
+
+    def test_completion_time_estimation(self):
+        scaler = AdaptiveScaler(cooldown_seconds=0)
+        decision = scaler.evaluate(
+            pending_tasks=[{"tag": "gcam"}] * 4,
+            active_workers={"gcam": 2},
+            recent_completions=[
+                {"duration_s": 60},
+                {"duration_s": 80},
+            ],
+        )
+        assert decision.predicted_completion_time is not None
+
+    def test_reset_cooldown(self):
+        scaler = AdaptiveScaler(cooldown_seconds=9999)
+        scaler.evaluate(
+            pending_tasks=[{"tag": "x"}],
+            active_workers={"x": 0},
+        )
+        scaler.reset_cooldown()
+        decision = scaler.evaluate(
+            pending_tasks=[{"tag": "x"}],
+            active_workers={"x": 0},
+        )
+        assert decision.has_changes
+
+    def test_decision_history(self):
+        scaler = AdaptiveScaler(cooldown_seconds=0)
+        scaler.evaluate(
+            pending_tasks=[{"tag": "a"}],
+            active_workers={"a": 0},
+        )
+        assert len(scaler.decision_history) == 1

--- a/tests/unit/test_ml_features.py
+++ b/tests/unit/test_ml_features.py
@@ -1,0 +1,105 @@
+"""Tests for scalable.ml.features — feature extraction."""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from scalable.ml.features import FeatureExtractor
+
+
+@pytest.fixture
+def sample_records():
+    return pd.DataFrame(
+        {
+            "task_name": ["run_gcam", "run_gcam", "run_gcam", "run_stitches", "run_stitches"],
+            "component": ["gcam", "gcam", "gcam", "stitches", "stitches"],
+            "duration_s": [120.0, 150.0, 130.0, 60.0, 55.0],
+            "requested_cpus": [4, 4, 6, 2, 2],
+            "requested_memory_bytes": [8e9, 8e9, 12e9, 4e9, 4e9],
+            "requested_workers": [2, 2, 3, 1, 1],
+            "target": ["slurm", "slurm", "slurm", "local", "local"],
+        }
+    )
+
+
+class TestFeatureExtractor:
+    def test_extract_from_history_empty(self):
+        extractor = FeatureExtractor()
+        result = extractor.extract_from_history(pd.DataFrame())
+        assert result.empty
+
+    def test_extract_from_history_produces_features(self, sample_records):
+        extractor = FeatureExtractor()
+        result = extractor.extract_from_history(sample_records)
+        assert not result.empty
+        assert "task_name_hash" in result.columns
+        assert "component_hash" in result.columns
+        assert "requested_cpus_num" in result.columns
+        assert "hist_mean_duration" in result.columns
+        assert "hist_count" in result.columns
+        assert len(result) == len(sample_records)
+
+    def test_extract_from_history_rolling_stats(self, sample_records):
+        extractor = FeatureExtractor()
+        result = extractor.extract_from_history(sample_records)
+        # First row should have 0 for rolling stats (no prior history)
+        assert result["hist_mean_duration"].iloc[0] == 0
+        # Second row of same task should have prior stats
+        assert result["hist_mean_duration"].iloc[1] > 0
+
+    def test_extract_from_task_basic(self):
+        extractor = FeatureExtractor()
+        result = extractor.extract_from_task(
+            task_name="run_gcam",
+            input_features={"scenario_count": 20, "years": 85},
+            component="gcam",
+            target="slurm",
+        )
+        assert len(result) == 1
+        assert "task_name_hash" in result.columns
+        assert "input_scenario_count" in result.columns
+        assert "input_years" in result.columns
+        assert result["input_scenario_count"].iloc[0] == 20
+
+    def test_extract_from_task_no_features(self):
+        extractor = FeatureExtractor()
+        result = extractor.extract_from_task(
+            task_name="run_gcam",
+            input_features=None,
+            component="gcam",
+            target=None,
+        )
+        assert len(result) == 1
+        assert "task_name_hash" in result.columns
+
+    def test_extract_from_task_with_history_stats(self):
+        extractor = FeatureExtractor()
+        stats = {"mean_duration": 120.0, "p95_duration": 150.0, "mean_memory": 8e9, "count": 5}
+        result = extractor.extract_from_task(
+            task_name="run_gcam",
+            input_features=None,
+            component="gcam",
+            target="slurm",
+            history_stats=stats,
+        )
+        assert result["hist_mean_duration"].iloc[0] == 120.0
+        assert result["hist_p95_duration"].iloc[0] == 150.0
+
+    def test_compute_history_stats_empty(self):
+        extractor = FeatureExtractor()
+        stats = extractor.compute_history_stats(pd.DataFrame(), "run_gcam")
+        assert stats["count"] == 0
+        assert stats["mean_duration"] == 0
+
+    def test_compute_history_stats_with_data(self, sample_records):
+        extractor = FeatureExtractor()
+        stats = extractor.compute_history_stats(sample_records, "run_gcam")
+        assert stats["count"] == 3
+        assert stats["mean_duration"] > 0
+        assert stats["p95_duration"] >= stats["mean_duration"]
+
+    def test_compute_history_stats_with_target(self, sample_records):
+        extractor = FeatureExtractor()
+        stats = extractor.compute_history_stats(sample_records, "run_stitches", "local")
+        assert stats["count"] == 2

--- a/tests/unit/test_ml_models.py
+++ b/tests/unit/test_ml_models.py
@@ -1,0 +1,101 @@
+"""Tests for scalable.ml.models — ML model wrappers."""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from scalable.ml.models import ModelQuality, PredictionResult, ResourceModel
+
+
+class TestPredictionResult:
+    def test_creation(self):
+        p = PredictionResult(point=100.0, lower=80.0, upper=120.0, confidence=0.9)
+        assert p.point == 100.0
+        assert p.lower == 80.0
+        assert p.upper == 120.0
+
+    def test_to_dict(self):
+        p = PredictionResult(point=50.0)
+        d = p.to_dict()
+        assert d["point"] == 50.0
+        assert d["confidence"] == 0.95
+
+
+class TestModelQuality:
+    def test_creation(self):
+        q = ModelQuality(
+            mae=5.0, rmse=7.0, r2=0.85, coverage=0.92,
+            n_samples=100, model_type="gradient_boosting", target_name="duration"
+        )
+        assert q.mae == 5.0
+        assert q.r2 == 0.85
+
+    def test_to_dict(self):
+        q = ModelQuality(
+            mae=5.0, rmse=7.0, r2=0.85, coverage=0.92,
+            n_samples=100, model_type="rf", target_name="mem"
+        )
+        d = q.to_dict()
+        assert d["model_type"] == "rf"
+        assert d["n_samples"] == 100
+
+
+class TestResourceModel:
+    def test_not_fitted_raises(self):
+        model = ResourceModel()
+        with pytest.raises(RuntimeError, match="not fitted"):
+            model.predict(pd.DataFrame({"x": [1]}))
+
+    def test_fit_empty_data(self):
+        model = ResourceModel()
+        X = pd.DataFrame()
+        y = pd.Series(dtype=float)
+        model.fit(X, y)
+        assert model.is_fitted
+        # Predict returns fallback
+        result = model.predict(pd.DataFrame({"x": [1]}))
+        assert len(result) == 1
+
+    def test_fit_single_row(self):
+        model = ResourceModel()
+        X = pd.DataFrame({"feat1": [1.0]})
+        y = pd.Series([100.0])
+        model.fit(X, y)
+        assert model.is_fitted
+        result = model.predict(pd.DataFrame({"feat1": [1.0]}))
+        assert len(result) == 1
+        assert result[0].point == 100.0  # Median of single value
+
+    def test_fit_few_rows_uses_percentile_fallback(self):
+        model = ResourceModel()
+        X = pd.DataFrame({"feat1": [1.0, 2.0, 3.0]})
+        y = pd.Series([100.0, 200.0, 300.0])
+        model.fit(X, y)
+        assert model.is_fitted
+        result = model.predict(pd.DataFrame({"feat1": [2.0]}))
+        assert len(result) == 1
+        # Should work regardless of sklearn availability
+
+    def test_feature_importances_unfitted(self):
+        model = ResourceModel()
+        assert model.feature_importances() == {}
+
+    def test_model_types(self):
+        for model_type in ["gradient_boosting", "random_forest", "quantile_regression"]:
+            model = ResourceModel(model_type=model_type)
+            assert model.model_type == model_type
+
+    def test_save_load(self, tmp_path):
+        model = ResourceModel()
+        X = pd.DataFrame({"feat1": [1.0, 2.0]})
+        y = pd.Series([10.0, 20.0])
+        model.fit(X, y)
+
+        save_path = tmp_path / "test_model"
+        model.save(save_path)
+        assert (save_path / "metadata.json").exists()
+
+        loaded = ResourceModel.load(save_path)
+        assert loaded.is_fitted
+        assert loaded.model_type == model.model_type

--- a/tests/unit/test_phase5_telemetry_cli.py
+++ b/tests/unit/test_phase5_telemetry_cli.py
@@ -1,0 +1,79 @@
+"""Tests for Phase 5 telemetry EmulationEvent and CLI advise command."""
+
+from __future__ import annotations
+
+import pytest
+
+from scalable.telemetry.events import SCHEMA_VERSION, EmulationEvent
+
+
+class TestEmulationEvent:
+    def test_creation(self):
+        event = EmulationEvent(
+            run_id="run-123",
+            task_name="run_gcam",
+            component="gcam",
+            emulator_name="gcam_emulator",
+            source="emulator",
+            confidence=0.95,
+            fallback_reason=None,
+            domain_valid=True,
+            emulator_version="2",
+        )
+        assert event.run_id == "run-123"
+        assert event.source == "emulator"
+        assert event.event_type == "emulation"
+        assert event.schema_version == SCHEMA_VERSION
+
+    def test_to_dict(self):
+        event = EmulationEvent(
+            run_id="run-456",
+            task_name="run_stitches",
+            component="stitches",
+            emulator_name=None,
+            source="full_model",
+            confidence=None,
+            fallback_reason="emulator_not_registered",
+            domain_valid=True,
+        )
+        d = event.to_dict()
+        assert d["run_id"] == "run-456"
+        assert d["source"] == "full_model"
+        assert d["fallback_reason"] == "emulator_not_registered"
+
+    def test_timestamp_auto(self):
+        event = EmulationEvent(
+            run_id="r",
+            task_name="t",
+            component=None,
+            emulator_name=None,
+            source="full_model",
+            confidence=None,
+            fallback_reason=None,
+            domain_valid=True,
+        )
+        assert event.timestamp  # auto-populated
+
+
+class TestPhase5Settings:
+    def test_ml_settings_defaults(self):
+        from scalable.common import Settings
+
+        s = Settings()
+        assert s.ml_model_cache_dir == ".scalable/models"
+        assert s.emulator_registry_dir == ".scalable/emulators"
+        assert s.ml_enabled is True
+        assert s.emulation_enabled is False
+        assert s.emulation_confidence_threshold == 0.9
+
+
+class TestCLIAdvise:
+    def test_advise_parser_registration(self):
+        """Verify advise command is registered in CLI parser."""
+        from scalable.cli.main import _build_parser
+
+        parser = _build_parser()
+        # Check that 'advise' is a valid subcommand
+        # Parse with --help would SystemExit, so just verify no crash
+        # on the parser build
+        assert parser is not None

--- a/tests/unit/test_session_plan_objectives.py
+++ b/tests/unit/test_session_plan_objectives.py
@@ -43,7 +43,7 @@ class TestSessionPlanObjectives:
         session = ScalableSession.from_yaml(manifest_path, target="local")
         plan = session.plan(dry_run=True, objective="minimize cost", policy="safe")
         # Workers should be conservative
-        for tag, count in plan.scale_plan.workers_by_tag.items():
+        for _tag, count in plan.scale_plan.workers_by_tag.items():
             assert count >= 1
 
     def test_plan_minimize_time_aggressive(self, tmp_path):


### PR DESCRIPTION
Here is the pull request description for Phase 5:

---

## Phase 5: ML Optimization and Emulation

**Branch:** `version/2.0.0-phase5-ml-emulation` → `version/2.0.0`
**Plan:** [`plans/v2.0.0_phase5_plan.md`](plans/v2.0.0_phase5_plan.md)
**Prior phases:** Phase 1 (#20), Phase 2 (#21), Phase 3 (#22), Phase 4 (#23)
**Version:** `2.0.0a5`

---

### Summary

Phase 5 is the capstone phase of the v2.0.0 roadmap. It adds ML-backed resource prediction and scientific model emulation as first-class capabilities, completing Scalable's evolution from a Slurm-oriented launcher into a portable scientific-model execution control plane with optional ML services.

All ML features **degrade gracefully** to Phase 2 heuristics when training data is insufficient or `scalable[ml]` is not installed. Emulation is **opt-in** (off by default) and **uncertainty-aware** — predictions are never silently substituted for full model runs.

---

### What's new

#### ML Optimization (`scalable.ml`)
- **`LearnedAdvisor`** — ML-backed resource recommendations using gradient boosting, random forest, or quantile regression trained on telemetry history. Returns the same `ResourceRecommendation` payload as Phase 2's heuristic advisor.
- **`AdaptiveScaler`** — real-time adaptive worker scaling with configurable queue-depth thresholds, min/max worker bounds, and cooldown periods to prevent thrashing.
- **`FeatureExtractor`** — engineers features from telemetry records (rolling aggregates, task identity hashing) and user-provided input features for ML consumption.
- **`ResourceModel`** — unified sklearn wrapper with `fit`/`predict`/confidence intervals, model persistence via joblib, and percentile fallback when sklearn is unavailable.
- **`HyperparameterSearch`** — Dask-ML distributed tuning (hyperband, successive halving, random) with sklearn `RandomizedSearchCV` fallback.
- **`cross_validate_advisor()`** — model quality assessment with MAE, RMSE, R², and coverage metrics.

#### Model Emulation (`scalable.emulation`)
- **`@emulatable` decorator** — marks functions as emulation-capable with declared inputs, outputs, domain bounds, uncertainty requirements, and confidence thresholds.
- **`EmulatorRegistry`** — versioned emulator management with filesystem persistence, domain validation, and joblib serialization.
- **`EmulatorDispatch`** — confidence-gated routing between emulator and full model with full provenance recording of every dispatch decision.
- **`ActiveLearner`** — intelligent scenario selection using expected improvement, maximum uncertainty, or random acquisition strategies.
- **`GradientBoostingEmulator`** and **`RandomForestEmulator`** — surrogate model implementations with tree-based uncertainty estimation.
- **`calibrate_emulator()`** — uncertainty calibration assessment (coverage, sharpness).

#### CLI
- **`scalable advise`** — ML-backed resource recommendations from the command line. Supports `--task`, `--target`, `--model-type`, `--confidence`, `--format` (text/json). Degrades to heuristic advisor when ML unavailable.

#### Telemetry
- **`EmulationEvent`** — new event type tracking emulator dispatch decisions (source, confidence, fallback reason, domain validity).

#### Configuration
- `SCALABLE_ML_CACHE_DIR` — trained ML model cache location
- `SCALABLE_EMULATOR_DIR` — emulator registry storage
- `SCALABLE_ML` — enable/disable ML features (default: enabled)
- `SCALABLE_EMULATION` — enable/disable emulation (default: disabled)
- `SCALABLE_EMULATION_CONFIDENCE` — default confidence threshold (0.9)

#### Dependencies
- New `[project.optional-dependencies] ml` extra: `scikit-learn >= 1.3`, `dask-ml >= 2023.3.24`, `joblib >= 1.3`

---

### Stats

- **26 files changed** (+4,214 lines)
- **14 new source modules** across `scalable/ml/` and `scalable/emulation/`
- **1 new CLI command** (`scalable advise`)
- **75 new unit tests** — all passing
- **431 total unit tests** — zero regressions from Phases 1–4
- **ruff lint clean** on all new modules

---

### Design principles honored

| Principle | How it's satisfied |
|-----------|--------------------|
| AI proposes; Scalable disposes | ML predictions validated by deterministic policy before execution |
| Every plan is inspectable | Recommendations include feature importances, confidence intervals, training provenance |
| Manual overrides always win | Users can pin resources, disable ML, or force full-model execution |
| Emulators are opt-in and labeled | Default disabled; every result records whether it was emulated or full-model |
| Offline-compatible | All models trained/cached locally; no remote inference required |

---

### After this merge

The `version/2.0.0` branch will contain the **complete v2.0.0 feature set** across all 5 phases and can proceed toward release candidate stabilization.