### PR TITLE
Release: 2.0.0-beta.3

### DIFF
--- a/docs/tutorials/beginner/01_getting_started.rst
+++ b/docs/tutorials/beginner/01_getting_started.rst
@@ -4,10 +4,6 @@
 Beginner Tutorial 1: Your First Workflow
 ======================================================
 
-.. contents:: In This Tutorial
-   :local:
-   :depth: 2
-
 The Big Picture
 ----------------
 

--- a/docs/tutorials/beginner/02_manifest_system.rst
+++ b/docs/tutorials/beginner/02_manifest_system.rst
@@ -4,10 +4,6 @@
 Beginner Tutorial 2: Understanding the Manifest System
 ======================================================
 
-.. contents:: In This Tutorial
-   :local:
-   :depth: 2
-
 The Big Picture
 ----------------
 

--- a/docs/tutorials/beginner/03_scaling_strategies.rst
+++ b/docs/tutorials/beginner/03_scaling_strategies.rst
@@ -4,10 +4,6 @@
 Beginner Tutorial 3: How Distributed Computing Works
 ======================================================
 
-.. contents:: In This Tutorial
-   :local:
-   :depth: 2
-
 The Big Picture
 ----------------
 

--- a/docs/tutorials/beginner/04_caching_performance.rst
+++ b/docs/tutorials/beginner/04_caching_performance.rst
@@ -4,10 +4,6 @@
 Beginner Tutorial 4: Caching — Avoiding Redundant Work
 ======================================================
 
-.. contents:: In This Tutorial
-   :local:
-   :depth: 2
-
 The Big Picture
 ----------------
 

--- a/docs/tutorials/beginner/05_cloud_integration.rst
+++ b/docs/tutorials/beginner/05_cloud_integration.rst
@@ -4,10 +4,6 @@
 Beginner Tutorial 5: Cloud Computing Fundamentals
 ======================================================
 
-.. contents:: In This Tutorial
-   :local:
-   :depth: 2
-
 The Big Picture
 ----------------
 

--- a/docs/tutorials/beginner/06_telemetry.rst
+++ b/docs/tutorials/beginner/06_telemetry.rst
@@ -4,10 +4,6 @@
 Beginner Tutorial 6: Understanding What Happened
 ======================================================
 
-.. contents:: In This Tutorial
-   :local:
-   :depth: 2
-
 The Big Picture
 ----------------
 

--- a/docs/tutorials/beginner/07_error_handling.rst
+++ b/docs/tutorials/beginner/07_error_handling.rst
@@ -4,10 +4,6 @@
 Beginner Tutorial 7: When Things Go Wrong
 ======================================================
 
-.. contents:: In This Tutorial
-   :local:
-   :depth: 2
-
 The Big Picture
 ----------------
 

--- a/docs/tutorials/beginner/08_kubernetes.rst
+++ b/docs/tutorials/beginner/08_kubernetes.rst
@@ -4,10 +4,6 @@
 Beginner Tutorial 8: Container Orchestration with Kubernetes
 ======================================================
 
-.. contents:: In This Tutorial
-   :local:
-   :depth: 2
-
 The Big Picture
 ----------------
 

--- a/docs/tutorials/beginner/09_ml_emulation.rst
+++ b/docs/tutorials/beginner/09_ml_emulation.rst
@@ -4,10 +4,6 @@
 Beginner Tutorial 9: Machine Learning for Smarter Workflows
 ======================================================
 
-.. contents:: In This Tutorial
-   :local:
-   :depth: 2
-
 The Big Picture
 ----------------
 

--- a/docs/tutorials/beginner/10_ai_composition.rst
+++ b/docs/tutorials/beginner/10_ai_composition.rst
@@ -4,10 +4,6 @@
 Beginner Tutorial 10: AI-Assisted Workflow Development
 ======================================================
 
-.. contents:: In This Tutorial
-   :local:
-   :depth: 2
-
 The Big Picture
 ----------------
 


### PR DESCRIPTION
This pull request removes the "In This Tutorial" table of contents section from all beginner tutorial `.rst` files in the documentation. This change simplifies the layout of each tutorial by eliminating the local contents directive at the top of the files.

Documentation cleanup:

* Removed the `.. contents:: In This Tutorial` section (including `:local:` and `:depth: 2` options) from the following beginner tutorial files to streamline their structure:
  - `01_getting_started.rst`
  - `02_manifest_system.rst`
  - `03_scaling_strategies.rst`
  - `04_caching_performance.rst`
  - `05_cloud_integration.rst`
  - `06_telemetry.rst`
  - `07_error_handling.rst`
  - `08_kubernetes.rst`
  - `09_ml_emulation.rst`
  - `10_ai_composition.rst`