### PR TITLE
Release: 2.0.0-beta.5

### DIFF
--- a/docs/tutorials/advanced/index.rst
+++ b/docs/tutorials/advanced/index.rst
@@ -1,0 +1,51 @@
+.. _advanced_tutorials:
+
+======================================================
+Advanced Tutorials
+======================================================
+
+The following advanced tutorials assume familiarity with distributed computing
+concepts. If terms like "workers," "schedulers," "containers," or "declarative
+programming" are unfamiliar, please start with the :ref:`beginner_tutorials`
+first.
+
+Getting Started
+---------------
+
+.. toctree::
+   :maxdepth: 1
+
+   ../01_getting_started
+   ../02_manifest_system
+
+These introductory tutorials assume no prior Scalable experience. Start here
+if you are new to the framework.
+
+Core Capabilities
+-----------------
+
+.. toctree::
+   :maxdepth: 1
+
+   ../03_scaling_strategies
+   ../04_caching_performance
+   ../05_cloud_integration
+   ../06_telemetry
+   ../07_error_handling
+
+These tutorials cover Scalable's primary feature set. They assume you have
+completed the Getting Started tutorials and have a working local environment.
+
+Advanced Topics
+---------------
+
+.. toctree::
+   :maxdepth: 1
+
+   ../08_kubernetes
+   ../09_ml_emulation
+   ../10_ai_composition
+
+These tutorials explore Scalable's advanced and differentiating capabilities.
+They assume familiarity with the core features and, in some cases, access to
+external infrastructure (Kubernetes clusters, cloud accounts).

--- a/docs/tutorials/index.rst
+++ b/docs/tutorials/index.rst
@@ -26,53 +26,12 @@ Beginner Tutorials
    with the concepts, graduate to the advanced tutorials for production patterns.
 
 Advanced Tutorials
-===================
-
-The following advanced tutorials assume familiarity with distributed computing
-concepts. If terms like "workers," "schedulers," "containers," or "declarative
-programming" are unfamiliar, please start with the :ref:`beginner_tutorials`
-above.
-
-Getting Started
----------------
+-------------------
 
 .. toctree::
    :maxdepth: 1
 
-   01_getting_started
-   02_manifest_system
-
-These introductory tutorials assume no prior Scalable experience. Start here
-if you are new to the framework.
-
-Core Capabilities
------------------
-
-.. toctree::
-   :maxdepth: 1
-
-   03_scaling_strategies
-   04_caching_performance
-   05_cloud_integration
-   06_telemetry
-   07_error_handling
-
-These tutorials cover Scalable's primary feature set. They assume you have
-completed the Getting Started tutorials and have a working local environment.
-
-Advanced Topics
----------------
-
-.. toctree::
-   :maxdepth: 1
-
-   08_kubernetes
-   09_ml_emulation
-   10_ai_composition
-
-These tutorials explore Scalable's advanced and differentiating capabilities.
-They assume familiarity with the core features and, in some cases, access to
-external infrastructure (Kubernetes clusters, cloud accounts).
+   advanced/index
 
 Recommended Learning Path
 --------------------------


### PR DESCRIPTION
This pull request reorganizes the advanced tutorials documentation to improve clarity and navigation. The advanced tutorials content has been moved out of the main tutorials index and into a dedicated file, with a new structure and clearer sectioning for different topics.

Documentation reorganization:

* Moved all advanced tutorials content from `docs/tutorials/index.rst` into a new file `docs/tutorials/advanced/index.rst`, introducing clear sections for "Getting Started," "Core Capabilities," and "Advanced Topics" with corresponding `toctree` navigation. [[1]](diffhunk://#diff-17eebb188b11706f2c7e1a7d7910d8dbf4c363d9793623cf293370aae5c0bfd9R1-R51) [[2]](diffhunk://#diff-218c197c25fe42d9844897ef6d0b665999f9f95dc05adfac851fad92d18c0641L29-R34)
* Updated the main tutorials index (`docs/tutorials/index.rst`) to reference the new advanced tutorials index, simplifying the main index and improving the recommended learning path flow.